### PR TITLE
Correctly send last error to sender

### DIFF
--- a/cleanup.c
+++ b/cleanup.c
@@ -26,6 +26,7 @@ extern int dry_run;
 extern int am_server;
 extern int am_daemon;
 extern int am_receiver;
+extern int am_sender;
 extern int io_error;
 extern int keep_partial;
 extern int got_xfer_error;
@@ -238,15 +239,21 @@ NORETURN void _exit_cleanup(int code, const char *file, int line)
 		switch_step++;
 
 		if (exit_code && exit_code != RERR_SOCKETIO && exit_code != RERR_STREAMIO && exit_code != RERR_SIGNAL1
-		 && exit_code != RERR_TIMEOUT && !shutting_down && (protocol_version >= 31 || am_receiver)) {
-			if (line > 0) {
-				if (DEBUG_GTE(EXIT, 3)) {
-					rprintf(FINFO, "[%s] sending MSG_ERROR_EXIT with exit_code %d\n",
-						who_am_i(), exit_code);
+		 && exit_code != RERR_TIMEOUT && !shutting_down) {
+			if (protocol_version >= 31 || am_receiver) {
+				if (line > 0) {
+					if (DEBUG_GTE(EXIT, 3)) {
+						rprintf(FINFO, "[%s] sending MSG_ERROR_EXIT with exit_code %d\n",
+							who_am_i(), exit_code);
+					}
+					send_msg_int(MSG_ERROR_EXIT, exit_code);
 				}
-				send_msg_int(MSG_ERROR_EXIT, exit_code);
+				if (!am_sender)
+					io_flush(MSG_FLUSH); /* Be sure to send all messages */
+				noop_io_until_death();
 			}
-			noop_io_until_death();
+			else if (!am_sender)
+				io_flush(MSG_FLUSH); /* Be sure to send all messages */
 		}
 
 #include "case_N.h"

--- a/io.c
+++ b/io.c
@@ -1985,10 +1985,11 @@ static void sleep_for_bwlimit(int bytes_written)
 void io_flush(int flush_it_all)
 {
 	if (iobuf.out.len > iobuf.out_empty_len) {
-		if (flush_it_all) /* FULL_FLUSH: flush everything in the output buffers */
+		if (flush_it_all == FULL_FLUSH)        /* flush everything in the output buffers */
 			perform_io(iobuf.out.size - iobuf.out_empty_len, PIO_NEED_OUTROOM);
-		else /* NORMAL_FLUSH: flush at least 1 byte */
+		else if (flush_it_all == NORMAL_FLUSH) /* flush at least 1 byte */
 			perform_io(iobuf.out.size - iobuf.out.len + 1, PIO_NEED_OUTROOM);
+		                                       /* MSG_FLUSH: flush iobuf.msg only */
 	}
 	if (iobuf.msg.len)
 		perform_io(iobuf.msg.size, PIO_NEED_MSGROOM);

--- a/rsync.h
+++ b/rsync.h
@@ -178,6 +178,7 @@
 #define ATTRS_SET_NANO		(1<<2)
 #define ATTRS_SKIP_ATIME	(1<<3)
 
+#define MSG_FLUSH	2
 #define FULL_FLUSH	1
 #define NORMAL_FLUSH	0
 


### PR DESCRIPTION
Hi,

Here is a PR which sends last error messages to sender for a file-transfer which failed.
It helps especially with protocol < 31.
This can be useful for example to know that a FS is full.

Many thanks 👍

```
### Without :

/repository/mybigfile.iso
        539.26M   6%   11.21MB/s    0:11:01  
rsync: [sender] write error: Broken pipe (32)
rsync error: error in file IO (code 11) at io.c(831) [sender=3.1.2]

### With (of course the interesting message here is the first one) :

/repository/mybigfile.iso
        539.26M   6%   11.21MB/s    0:11:01  
rsync: write failed on "/repository/mybigfile.iso" (in bkp): Disc quota exceeded (69)
rsync error: error in file IO (code 11) at receiver.c(400) [receiver=3.1.2]
rsync error: error in file IO (code 11) at io.c(1633) [generator=3.1.2]
rsync: [sender] write error: Broken pipe (32)
rsync error: error in file IO (code 11) at io.c(831) [sender=3.1.2]
```

_Initial report [there](https://bugzilla.samba.org/show_bug.cgi?id=12522), pushed here by convenience._