### PR TITLE
Avoid sending whole file when transfer fails

### DIFF
--- a/cleanup.c
+++ b/cleanup.c
@@ -246,7 +246,7 @@ NORETURN void _exit_cleanup(int code, const char *file, int line)
 				}
 				send_msg_int(MSG_ERROR_EXIT, exit_code);
 			}
-			noop_io_until_death();
+			/* noop_io_until_death(); */
 		}
 
 #include "case_N.h"


### PR DESCRIPTION
Hi,

Here is a PR which stops file upload when it fails.
This can be useful for example when the remote FS is full, and client is uploading big files, preventing it from sending its whole file file for nothing...

Many thanks 👍

_Initial report [there](https://bugzilla.samba.org/show_bug.cgi?id=12525), pushed here by convenience._