### PR TITLE
zstd: Use `0' as default compression level

### DIFF
--- a/token.c
+++ b/token.c
@@ -72,7 +72,7 @@ void init_compression_level(void)
 	case CPRES_ZSTD:
 		min_level = skip_compression_level = ZSTD_minCLevel();
 		max_level = ZSTD_maxCLevel();
-		def_level = 3;
+		def_level = 0;
 		off_level = CLVL_NOT_SPECIFIED;
 		break;
 #endif


### PR DESCRIPTION
The default compression level for zstd is defined by ZSTD_CLEVEL_DEFAULT
and is currently `3'.

Use the special value `0' (which is controlled by ZSTD_CLEVEL_DEFAULT)
instead of `3'.

Signed-off-by: Sebastian Andrzej Siewior <sebastian@breakpoint.cc>