### PR TITLE
Add OpenSSL license exception also to COPYING

### DIFF
--- a/COPYING
+++ b/COPYING
@@ -673,7 +673,7 @@ the library.  If this is what you want to do, use the GNU Lesser General
 Public License instead of this License.  But first, please read
 <http://www.gnu.org/philosophy/why-not-lgpl.html>.
 
-REGARDING OPENSSL
+REGARDING OPENSSL AND XXHASH
 
 In addition, as a special exception, the copyright holders give
 permission to dynamically link rsync with the OpenSSL and xxhash

--- a/COPYING
+++ b/COPYING
@@ -672,3 +672,12 @@ may consider it more useful to permit linking proprietary applications with
 the library.  If this is what you want to do, use the GNU Lesser General
 Public License instead of this License.  But first, please read
 <http://www.gnu.org/philosophy/why-not-lgpl.html>.
+
+REGARDING OPENSSL
+
+In addition, as a special exception, the copyright holders give
+permission to dynamically link rsync with the OpenSSL and xxhash
+libraries when those libraries are being distributed in compliance
+with their license terms, and to distribute a dynamically linked
+combination of rsync and these libraries.  This is also considered
+to be covered under the GPL's System Libraries exception.


### PR DESCRIPTION
Add the OpenSSL license exception also to the COPYING file which
contains the license related information.

Signed-off-by: Sebastian Andrzej Siewior <sebastian@breakpoint.cc>