### PR TITLE
x86-64 SIMD build fixes

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -200,48 +200,45 @@ AC_ARG_ENABLE(simd,
     AS_HELP_STRING([--enable-simd],[enable SIMD optimizations (requires c++)]))
 
 if test x"$enable_simd" = x"yes"; then
-    # For x86-64 SIMD, g++ 5+ or clang++ 7+ is required
+    # For x86-64 SIMD, g++ >=5 or clang++ >=7 is required
     if test x"$build_cpu" = x"x86_64"; then
-        if test x"$CXX" != x""; then
-            CXX_OK=
-            CXX_VERSION=$($CXX --version | head -n 1)
-            if `echo $CXX_VERSION | grep "^g++" >/dev/null`; then
-                CXX_BRAND="g++"
-            elif `echo $CXX_VERSION | grep "clang" >/dev/null`; then
-                CXX_BRAND="clang++"
-            fi
+	if test x"$CXX" != x""; then
+	    CXX_OK=
+	    CXX_VERSION=`$CXX --version | head -n 1`
+	    case "$CXX_VERSION" in
+	    g++*)
+		CXX_VERSION=`$CXX -dumpversion | sed 's/\..*//g'`
+		if test "$CXX_VERSION" -ge "5"; then
+		    CXX_OK=yes
+		fi
+		;;
+	    clang*)
+		# $CXX -dumpversion would have been ideal, but is broken on older clang
+		CXX_VERSION=`echo "$CXX_VERSION" | sed 's/.*version //g' | sed 's/\..*//g'`
+		if test "$CXX_VERSION" -ge "7"; then
+		    CXX_OK=yes
+		fi
+		;;
+	    esac
 
-            if test x"$CXX_BRAND" = x"g++"; then
-                CXX_VERSION=$($CXX -dumpversion | sed 's/\..*//g')
-                if test "$CXX_VERSION" -ge "5"; then
-                    CXX_OK=yes
-                fi
-            elif test x"$CXX_BRAND" = x"clang++"; then
-                # $CXX -dumpversion would have been ideal, but is broken on older clang
-                CXX_VERSION=$(echo $CXX_VERSION | sed 's/.*version //g' | sed 's/\..*//g')
-                if test "$CXX_VERSION" -ge "7"; then
-                    CXX_OK=yes
-                fi
-            fi
-
-            if test x"$CXX_OK" = x"yes"; then
-                # AC_MSG_RESULT() called below
-                SIMD="$SIMD x86_64"
-            else
-                AC_MSG_RESULT(no)
-                AC_MSG_ERROR([Failed to find g++ 5+ or clang++ 7+ for SIMD optimizations.
-Omit --enable-simd to continue without it. ($CXX, $CXX_BRAND, $CXX_VERSION)])
-        	fi
-        fi
+	    if test x"$CXX_OK" = x"yes"; then
+		# AC_MSG_RESULT() is called below.
+		SIMD="$SIMD x86_64"
+	    else
+		AC_MSG_RESULT(error)
+		AC_MSG_ERROR([Failed to find g++ >=5 or clang++ >=7 for SIMD optimizations.
+Omit --enable-simd to continue without it. ($CXX, $CXX_VERSION)])
+	    fi
+	fi
     fi
 fi
 
 if test x"$SIMD" != x""; then
-    SIMD=`echo "$SIMD" | sed -e 's/^ *//'`
+    SIMD=`echo "$SIMD" | sed 's/^ *//'`
     AC_MSG_RESULT([yes ($SIMD)])
     AC_DEFINE(HAVE_SIMD, 1, [Define to 1 to enable SIMD optimizations])
-    SIMD=`echo "\\$(SIMD_$SIMD)" | sed 's/ /) $(SIMD_/g'`;
-    # We only use g++ for its target attribute dispatching, disable unneeded bulky features
+    SIMD=`echo "\\\$(SIMD_$SIMD)" | sed 's/ /) $(SIMD_/g'`
+    # We only use c++ for its target attribute dispatching, disable unneeded bulky features
     CXXFLAGS="$CXXFLAGS -fno-exceptions -fno-rtti"
 else
     AC_MSG_RESULT(no)

--- a/configure.ac
+++ b/configure.ac
@@ -197,22 +197,42 @@ SIMD=
 
 AC_MSG_CHECKING([whether to enable SIMD optimizations])
 AC_ARG_ENABLE(simd,
-    AS_HELP_STRING([--enable-simd],[enable SIMD optimizations (requires g++)]))
+    AS_HELP_STRING([--enable-simd],[enable SIMD optimizations (requires c++)]))
 
 if test x"$enable_simd" = x"yes"; then
-    # For x86-64 SIMD, g++ is also required
+    # For x86-64 SIMD, g++ 5+ or clang++ 7+ is required
     if test x"$build_cpu" = x"x86_64"; then
-	case "$CXX" in
-	*g++)
-	    # AC_MSG_RESULT() is called below.
-	    SIMD="$SIMD x86_64"
-	    ;;
-	*)
-	    AC_MSG_RESULT(no)
-	    AC_MSG_ERROR(Failed to find g++ for SIMD speedups.
-Omit --enable-simd to continue without it.)
-	    ;;
-	esac
+        if test x"$CXX" != x""; then
+            CXX_OK=
+            CXX_VERSION=$($CXX --version | head -n 1)
+            if `echo $CXX_VERSION | grep "^g++" >/dev/null`; then
+                CXX_BRAND="g++"
+            elif `echo $CXX_VERSION | grep "clang" >/dev/null`; then
+                CXX_BRAND="clang++"
+            fi
+
+            if test x"$CXX_BRAND" = x"g++"; then
+                CXX_VERSION=$($CXX -dumpversion | sed 's/\..*//g')
+                if test "$CXX_VERSION" -ge "5"; then
+                    CXX_OK=yes
+                fi
+            elif test x"$CXX_BRAND" = x"clang++"; then
+                # $CXX -dumpversion would have been ideal, but is broken on older clang
+                CXX_VERSION=$(echo $CXX_VERSION | sed 's/.*version //g' | sed 's/\..*//g')
+                if test "$CXX_VERSION" -ge "7"; then
+                    CXX_OK=yes
+                fi
+            fi
+
+            if test x"$CXX_OK" = x"yes"; then
+                # AC_MSG_RESULT() called below
+                SIMD="$SIMD x86_64"
+            else
+                AC_MSG_RESULT(no)
+                AC_MSG_ERROR([Failed to find g++ 5+ or clang++ 7+ for SIMD optimizations.
+Omit --enable-simd to continue without it. ($CXX, $CXX_BRAND, $CXX_VERSION)])
+        	fi
+        fi
     fi
 fi
 
@@ -220,7 +240,7 @@ if test x"$SIMD" != x""; then
     SIMD=`echo "$SIMD" | sed -e 's/^ *//'`
     AC_MSG_RESULT([yes ($SIMD)])
     AC_DEFINE(HAVE_SIMD, 1, [Define to 1 to enable SIMD optimizations])
-    SIMD=`echo "$SIMD" | sed -e 's/[[^ ]]\+/$(SIMD_&)/g'`
+    SIMD=`echo "\\$(SIMD_$SIMD)" | sed 's/ /) $(SIMD_/g'`;
     # We only use g++ for its target attribute dispatching, disable unneeded bulky features
     CXXFLAGS="$CXXFLAGS -fno-exceptions -fno-rtti"
 else


### PR DESCRIPTION
configure.ac was modified to detect g++ 5+ and clang++ 7+. Additionally
some script malfunctions on FreeBSD were corrected.

The get_checksum1() code has been modified to fix clang and g++ 10
compilation.

This version of the code and configure.ac has been tested on:

Ubuntu 16 - gcc 7.3.0, clang 6.0.0
Debian 10 - gcc 5.4.0, 6.4.0, 7.2.0, 8.4.0, 9.2.1, 10.0.1, clang 5.0.2,
6.0.1, 7.0.1, 8.0.0, 9.0.0, 10.0.0
ArchLinux 20200605 - gcc 10.1.0, clang 10.0.0
FreeBSD 12.1 - gcc 9.3.0, clang 8.0.1

It is unknown if it will work on gcc 5.0-5.3, but the script currently
allows it.