### PR TITLE
Prevent unnecessary xattr warning by reordering header inclusion.

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -100,6 +100,7 @@ rsync$(EXEEXT): $(OBJS)
 
 $(OBJS): $(HEADERS)
 $(CHECK_OBJS): $(HEADERS)
+tls.o xattrs.o: lib/sysxattrs.h
 options.o: latest-year.h help-rsync.h help-rsyncd.h
 exclude.o: default-cvsignore.h
 loadparm.o: default-dont-compress.h

--- a/lib/sysxattrs.h
+++ b/lib/sysxattrs.h
@@ -1,9 +1,9 @@
 #ifdef SUPPORT_XATTRS
 
-#if defined HAVE_ATTR_XATTR_H
-#include <attr/xattr.h>
-#elif defined HAVE_SYS_XATTR_H
+#if defined HAVE_SYS_XATTR_H
 #include <sys/xattr.h>
+#elif defined HAVE_ATTR_XATTR_H
+#include <attr/xattr.h>
 #elif defined HAVE_SYS_EXTATTR_H
 #include <sys/extattr.h>
 #endif


### PR DESCRIPTION
xattr headers have been provided by glibc (at least on Linux/glibc) for many years now.
Reorder the inclusion of xattr headers to attempt compatibility/legacy after the common case.
This prevents the warning without changing compatibility to old/non-glibc systems.
