### PR TITLE
configure.ac: Improve check for g++

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -207,7 +207,7 @@ if test x"$enable_simd" != x"no"; then
 	if test x"$CXX" != x""; then
 	    CXX_VERSION=`$CXX --version 2>/dev/null | head -n 1`
 	    case "$CXX_VERSION" in
-	    g++*)
+	    *g++*)
 		CXX_VERSION=`$CXX -dumpversion | sed 's/\..*//g'`
 		if test "$CXX_VERSION" -ge "5"; then
 		    CXX_OK=yes


### PR DESCRIPTION
Gentoo Linux has `x86_64-pc-linux-gnu-g++` (or similar string for other arches)
in CXX variable when gcc is being used and thus the check always fails.

Signed-off-by: Lars Wendler <polynomial-c@gentoo.org>