### PR TITLE
lib/md5-asm-x86_64.s: fix build with Apple Clang

### DIFF
--- a/lib/md5-asm-x86_64.s
+++ b/lib/md5-asm-x86_64.s
@@ -27,9 +27,14 @@
 .text
 .align 16
 
+#ifndef __apple_build_version__
 .globl md5_process_asm
 .type md5_process_asm,@function
 md5_process_asm:
+#else
+.globl _md5_process_asm
+_md5_process_asm:
+#endif
 	push	%rbp
 	push	%rbx
 	push	%r12
@@ -689,5 +694,9 @@ md5_process_asm:
 	pop	%rbx
 	pop	%rbp
 	ret
+#ifndef __apple_build_version__
 .L_md5_process_asm_end:
 .size md5_process_asm,.L_md5_process_asm_end-md5_process_asm
+#else
+L_md5_process_asm_end:
+#endif


### PR DESCRIPTION
The Mach-O x86-64 model doesn't seem to support `.type` and `.size` directives in assembly. Add ifdefs that should allow for the file to build without issues in Apple Clang.

See also:
- https://github.com/micropython/micropython/pull/73
- https://stackoverflow.com/a/19725269