### PR TITLE
Pass --noexecstack to assembler.

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -135,7 +135,7 @@ simd-checksum-x86_64.o: simd-checksum-x86_64.cpp
 	$(CXX) $(CXXFLAGS) $(CPPFLAGS) -c -o $@ $(srcdir)/simd-checksum-x86_64.cpp
 
 lib/md5-asm-x86_64.o: lib/md5-asm-x86_64.s
-	$(CC) -c -o $@ $(srcdir)/lib/md5-asm-x86_64.s
+	$(CC) -Wa,--noexecstack -c -o $@ $(srcdir)/lib/md5-asm-x86_64.s
 
 tls$(EXEEXT): $(TLS_OBJ)
 	$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $(TLS_OBJ) $(LIBS)


### PR DESCRIPTION
This prevents Linux from rightfully complaining about an executable stack segment, which is widely considered a security hazard.
