### PR TITLE
lib/md5-asm-x86_64.S: fix build on other macOS compilers

### DIFF
--- a/lib/md5-asm-x86_64.S
+++ b/lib/md5-asm-x86_64.S
@@ -32,7 +32,7 @@
 .text
 .align 16
 
-#ifndef __apple_build_version__
+#ifndef __APPLE__
 .globl md5_process_asm
 .type md5_process_asm,@function
 md5_process_asm:
@@ -699,7 +699,7 @@ _md5_process_asm:
 	pop	%rbx
 	pop	%rbp
 	ret
-#ifndef __apple_build_version__
+#ifndef __APPLE__
 .L_md5_process_asm_end:
 .size md5_process_asm,.L_md5_process_asm_end-md5_process_asm
 #else


### PR DESCRIPTION
Follow-up from #25. Looks like the issue isn't just with Apple's clang; it affects other compilers on macOS as well. Adjust the `ifndef` to just check if OS is macOS rather than check if compiler is Apple clang.