### PR TITLE
Make --backup be set when --backup-dir is used

### DIFF
--- a/options.c
+++ b/options.c
@@ -2222,6 +2222,7 @@ int parse_arguments(int *argc_p, const char ***argv_p)
 	}
 	if (backup_dir) {
 		size_t len;
+		make_backups = 1; /* --backup-dir implies --backup */
 		while (*backup_dir == '.' && backup_dir[1] == '/')
 			backup_dir += 2;
 		if (*backup_dir == '.' && backup_dir[1] == '\0')

--- a/rsync.1.md
+++ b/rsync.1.md
@@ -842,7 +842,7 @@ your home directory (remove the '=' for that).
 
 0.  `--backup-dir=DIR`
 
-    In combination with the `--backup` option, this tells rsync to store all
+    This implies the `--backup` option, and tells rsync to store all
     backups in the specified directory on the receiving side.  This can be used
     for incremental backups.  You can additionally specify a backup suffix
     using the `--suffix` option (otherwise the files backed up in the specified


### PR DESCRIPTION
Hello Wayne,

I'm sending this patch we currently apply in the Debian packaging of rsync, I believe it would be nice to have it upstreamed.

Thanks,