### PR TITLE
Makefile.in: Use srcdir for installing rsync-ssl

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -77,7 +77,7 @@ all: Makefile rsync$(EXEEXT) stunnel-rsyncd.conf @MAKE_MAN@
 install: all
 	-${MKDIR_P} ${DESTDIR}${bindir}
 	${INSTALLCMD} ${INSTALL_STRIP} -m 755 rsync$(EXEEXT) ${DESTDIR}${bindir}
-	${INSTALLCMD} -m 755 rsync-ssl ${DESTDIR}${bindir}
+	${INSTALLCMD} -m 755 $(srcdir)/rsync-ssl ${DESTDIR}${bindir}
 	-${MKDIR_P} ${DESTDIR}${mandir}/man1
 	-${MKDIR_P} ${DESTDIR}${mandir}/man5
 	if test -f rsync.1; then ${INSTALLMAN} -m 644 rsync.1 ${DESTDIR}${mandir}/man1; fi


### PR DESCRIPTION
When building out of source tree, we can't find rsync-ssl in the current
directory and installation fails.  Fix it by using the srcdir variable for the
path to rsync-ssl.

Signed-off-by: Hiroshi Takekawa <sian.ht@gmail.com>