### PR TITLE
Add "open noatime" module option to rsyncd.conf

### DIFF
--- a/clientserver.c
+++ b/clientserver.c
@@ -38,6 +38,7 @@ extern int preserve_xattrs;
 extern int kluge_around_eof;
 extern int daemon_over_rsh;
 extern int munge_symlinks;
+extern int open_noatime;
 extern int sanitize_paths;
 extern int numeric_ids;
 extern int filesfrom_fd;
@@ -990,6 +991,8 @@ static int rsync_module(int f_in, int f_out, int i, const char *addr, const char
 		orig_early_argv = NULL;
 
 	munge_symlinks = save_munge_symlinks; /* The client mustn't control this. */
+	open_noatime = lp_open_noatime(module_id);
+
 	if (am_daemon > 0)
 		msgs2stderr = 0; /* A non-rsh-run daemon doesn't have stderr for msgs. */
 

--- a/daemon-parm.txt
+++ b/daemon-parm.txt
@@ -57,6 +57,7 @@ BOOL	ignore_nonreadable	False
 BOOL	list			True
 BOOL	munge_symlinks		(BOOL)-1
 BOOL	numeric_ids		(BOOL)-1
+BOOL	open_noatime		False
 BOOL	read_only		True
 BOOL	reverse_lookup		True
 BOOL	strict_modes		True

--- a/rsyncd.conf.5.md
+++ b/rsyncd.conf.5.md
@@ -424,6 +424,15 @@ the values of parameters.  See the GLOBAL PARAMETERS section for more details.
     Helpful hint: you probably want to specify "refuse options = delete" for a
     write-only module.
 
+0.  `open noatime`
+
+    This parameter tells the rsync daemon to open files with the O_NOATIME flag
+    (on systems that support it) to avoid changing the access time of the files
+    that are being transferred.  If your OS does not support the O_NOATIME flag
+    then rsync will silently ignore this option.  Note also that some
+    filesystems are mounted to avoid updating the atime on read access even
+    without the O_NOATIME flag being set.
+
 0.  `list`
 
     This parameter determines whether this module is listed when the client


### PR DESCRIPTION
I think it's pretty useful to tell an rsync daemon to also use A_NOATIME when opening files. This should do it.
paul@debian.org