### PR TITLE
Add FreeBSD CI

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,0 +1,10 @@
+task:
+  name: FreeBSD
+  freebsd_instance:
+    image: freebsd-12-1-release-amd64
+  install_script:
+    - ln -s /usr/local/bin/bash /bin/bash
+  script:
+    - CPPFLAGS=-I/usr/local/include/ LDFLAGS=-L/usr/local/lib/ ./configure
+    - make
+    - ./rsync --version


### PR DESCRIPTION
Hi,

This is a very first version of a FreeBSD CI.
It's based on Cirrus CI : https://cirrus-ci.org
Used in other projects, it works perfectly.

Once we have this build properly working, goal is then to include tests, as in the Linux CI.

You should then have to enable Cirrus CI on this repository Wayne, if you're OK to go further with this.

Many thanks 👍