### PR TITLE
Improve FreeBSD tests

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -3,7 +3,8 @@ task:
   freebsd_instance:
     image: freebsd-12-1-release-amd64
   prep_script:
-    - mount -t tmpfs -o size=128m tmpfs /var/tmp
+    - dd if=/dev/zero of=/tmp/zpool bs=1M count=1024
+    - zpool create -m `pwd`/testtmp zpool /tmp/zpool
     - pkg install -y autotools xxhash zstd liblz4 openssl bash
     - ln -s /usr/local/bin/bash /bin/bash
   configure_script:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -3,6 +3,7 @@ task:
   freebsd_instance:
     image: freebsd-12-1-release-amd64
   prep_script:
+    - mount -t tmpfs -o size=128m tmpfs /var/tmp
     - pkg install -y autotools xxhash zstd liblz4 openssl bash
     - ln -s /usr/local/bin/bash /bin/bash
   configure_script:

--- a/runtests.sh
+++ b/runtests.sh
@@ -249,7 +249,7 @@ prep_scratch() {
     [ -d "$scratchdir" ] && chmod -R u+rwX "$scratchdir" && rm -rf "$scratchdir"
     mkdir "$scratchdir"
     # Get rid of default ACLs and dir-setgid to avoid confusing some tests.
-    $setfacl_nodef "$scratchdir" || true
+    $setfacl_nodef "$scratchdir" 2>/dev/null || true
     chmod g-s "$scratchdir"
     case "$srcdir" in
     /*) ln -s "$srcdir" "$scratchdir/src" ;;

--- a/testsuite/chown.test
+++ b/testsuite/chown.test
@@ -37,6 +37,13 @@ EOF
 	    done
 	}
 	;;
+    freebsd*)
+	chown() {
+	    own=$1
+	    shift
+	    setextattr -h user "rsync.%stat" "100644 0,0 $own" "${@}"
+	}
+	;;
     *)
 	chown() {
 	    own=$1

--- a/testsuite/devices.test
+++ b/testsuite/devices.test
@@ -50,6 +50,20 @@ echo "$mode $maj,$min 0:0" > rsync.%stat
 EOF
 	}
 	;;
+    freebsd*)
+	mknod() {
+	    fn="$1"
+	    case "$2" in
+	    p) mode=10644 ;;
+	    c) mode=20644 ;;
+	    b) mode=60644 ;;
+	    esac
+	    maj="${3:-0}"
+	    min="${4:-0}"
+	    touch "$fn"
+	    setextattr -h user "rsync.%stat" "$mode $maj,$min 0:0" "$fn"
+	}
+	;;
     *)
 	mknod() {
 	    fn="$1"

--- a/testsuite/xattrs.test
+++ b/testsuite/xattrs.test
@@ -53,7 +53,7 @@ freebsd*)
 	setextattr -h user "$xnam" "$xval" "${@}"
     }
     xls() {
-	lsextattr -h -q user "${@}" | tr '[[:space:]]' '\n' | xargs -I % getextattr -q user % "${@}"
+	for f in "${@}"; do lsextattr -h -q user "$f" | tr '[[:space:]]' '\n' | sort | xargs -I % getextattr user % "$f"; done
     }
     RSYNC_PREFIX='rsync'
     RUSR='rsync'

--- a/testsuite/xattrs.test
+++ b/testsuite/xattrs.test
@@ -45,6 +45,19 @@ EOF
     RSYNC_PREFIX='rsync'
     RUSR='rsync.nonuser'
     ;;
+freebsd*)
+    xset() {
+	xnam="$1"
+	xval="$2"
+	shift 2
+	setextattr -h user "$xnam" "$xval" "${@}"
+    }
+    xls() {
+	lsextattr -h -q user "${@}" | tr '[[:space:]]' '\n' | xargs -I % getextattr -q user % "${@}"
+    }
+    RSYNC_PREFIX='rsync'
+    RUSR='rsync'
+    ;;
 *)
     xset() {
 	xnam="$1"

--- a/testsuite/xattrs.test
+++ b/testsuite/xattrs.test
@@ -53,7 +53,7 @@ freebsd*)
 	setextattr -h user "$xnam" "$xval" "${@}"
     }
     xls() {
-	for f in "${@}"; do lsextattr -h -q user "$f" | tr '[[:space:]]' '\n' | sort | xargs -I % getextattr user % "$f"; done
+	for f in "${@}"; do lsextattr -q -h user "$f" | tr '[[:space:]]' '\n' | sort | xargs -I % getextattr -h user % "$f"; done
     }
     RSYNC_PREFIX='rsync'
     RUSR='rsync'


### PR DESCRIPTION
Hi,

Let's try to improve FreeBSD tests :
- mute the `acl_get_file() failed: Operation not supported` errors in non-acl tests ;
- use the correct attr commands in tests using them ;
- create a ZFS pool and mount it on `testtmp` dir, so that tests will run in this dedicated FS, which then makes `chmod-temp-dir` to run, as well as `dir-sgid` (on UFS, sticky bit is not inherited, whereas it is on ZFS).

Thx 👍 