### PR TITLE
Enable FreeBSD CI ssl

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -16,3 +16,5 @@ task:
     - /usr/local/bin/rsync --version
   test_script:
     - make check
+  ssl_file_list_script:
+    - /usr/local/bin/rsync-ssl --no-motd download.samba.org::rsyncftp/ || true


### PR DESCRIPTION
Hi,

I re-enabled `rsync-ssl` test in FreeBSD CI, as `bash` is already built-in.

Thx 👍 