### PR TITLE
Force git line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf


### PR DESCRIPTION
Hi,

If we want to build a Windows/Cygwin CI, we'll need to tell git not to transform line endings.
I simply forgot it in #67, while I clearly needed it in other projects' Cygwin CI.

Sounds like you also faced the `\r` issue in some of your CI tests @WayneD.
This will then help.

Ben