### PR TITLE
Use RSYNC_MAX_SKIPPED on FreeBSD CI

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -17,6 +17,6 @@ freebsd_task:
   info_script:
     - rsync --version
   test_script:
-    - make check
+    - RSYNC_MAX_SKIPPED=3 make check
   ssl_file_list_script:
     - rsync-ssl --no-motd download.samba.org::rsyncftp/ || true


### PR DESCRIPTION
Hi,

Let's also use `RSYNC_MAX_SKIPPED` on FreeBSD CI.

Thx 👍