### PR TITLE
Add link to manpage on GitHub

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ options.  To get a complete list of supported options type:
 
     rsync --help
 
-See the manpage for more detailed information.
+See the [manpage](https://github.com/WayneD/rsync/blob/master/rsync.1.md) for more detailed information.
 
 
 BUILDING AND INSTALLING


### PR DESCRIPTION
Might not be wanted, since there are also other options to display the manpage.