### PR TITLE
Makefile.in: Avoid build reproducibility issue from locale glob sorting 

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -26,6 +26,12 @@ MKDIR_P=@MKDIR_P@
 VPATH=$(srcdir)
 SHELL=/bin/sh
 
+# We use globbing in commands, need to be deterministic about output
+# regardless of locale setting
+unexport LC_ALL
+LC_COLLATE=C
+export LC_COLLATE
+
 .SUFFIXES:
 .SUFFIXES: .c .o
 


### PR DESCRIPTION
The Makefile calls awk on a "*.c" glob. The results of this glob are sorted
but the order depends on the locale settings, particularly whether
"util.c" and "util2.c" sort before or after each other. In en_US.UTF-8
they sort one way, in C, they sort the other for example. The sorting
order changes the output binaries. The behaviour also changes depending
on whether SHELL (/bin/sh) is dash or bash, bash seems more sensitive
to this.

Specifying a C locale allows this to be deterministic.

Signed-off-by: Richard Purdie <richard.purdie@linuxfoundation.org>