### PR TITLE
Updated GLIBC check in configure.ac

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -411,7 +411,7 @@ yes
 			# http://www.v6.linux.or.jp/
 			AC_EGREP_CPP(yes, [
 #include <features.h>
-#if defined(__GLIBC__) && __GLIBC__ >= 2 && __GLIBC_MINOR__ >= 1
+#if defined(__GLIBC__) && (__GLIBC__ > 2 || (__GLIBC__ == 2 && __GLIBC_MINOR__ >= 1))
 yes
 #endif],
 				[ipv6type=$i;


### PR DESCRIPTION
The current GLIBC check does not consider we may see glibc 3.0 in the future.

It almost feels criminal submitting a very tiny PR like this, but it bothered me!