### PR TITLE
man: document possible format strings

### DIFF
--- a/rsync.1.md
+++ b/rsync.1.md
@@ -454,7 +454,7 @@ detailed description below for a complete description.
 --remote-option=OPT, -M  send OPTION to the remote side only
 --out-format=FORMAT      output updates using the specified FORMAT
 --log-file=FILE          log what we're doing to the specified FILE
---log-file-format=FMT    log updates using the specified FMT
+--log-file-format=FORMAT log updates using the specified FORMAT
 --password-file=FILE     read daemon-access password from FILE
 --early-input=FILE       use FILE for daemon's early exec input
 --list-only              list the files instead of copying them
@@ -487,7 +487,7 @@ accepted:
 --no-detach              do not detach from the parent
 --port=PORT              listen on alternate port number
 --log-file=FILE          override the "log file" setting
---log-file-format=FMT    override the "log format" setting
+--log-file-format=FORMAT override the "log format" setting
 --sockopts=OPTIONS       specify custom TCP options
 --verbose, -v            increase verbosity
 --ipv4, -4               prefer IPv4
@@ -4052,6 +4052,58 @@ contain output statements for non-interactive logins.
 If you are having trouble debugging filter patterns, then try specifying the
 `-vv` option.  At this level of verbosity rsync will show why each individual
 file is included or excluded.
+
+# FORMAT STRINGS
+
+The following forrmat strings are supported for options accepting a `FORMAT`
+parameter:
+
+0.  `%l` File length
+
+0.  `%U` File owner username
+
+0.  `%G` File owner group
+
+0.  `%p` PID
+
+0.  `%M` File modification time string
+
+0.  `%B` File mode
+
+0.  `%o` Operation
+
+0.  `%f` File name (with full path, if available)
+
+0.  `%n` File name
+
+0.  `%L` Link destination (or empty string, if not a link).
+    Hard link destinations will be prefixed with` => `, and symbolic link
+    destinations will be prefixed with ` -> `.
+
+0.  `%m` Module name
+
+0.  `%P` Full module path
+
+0.  `%t` Time string
+
+0.  `%u` Authorized user
+
+0.  `%b` Total data written
+
+0.  `%c` Total data read
+
+0.  `%c` Checksum
+
+0.  `%i` Itemized changes string (see description of `--itemize-changes`).
+
+# DAEMON FORMAT STRINGS
+
+The following forrmat strings are supported for options accepting a `FORMAT`
+parameter when running as a daemon:
+
+0.  `%h` Client hostname (based on reverse lookup).
+
+0.  `%a` Client address
 
 # EXIT VALUES
 

--- a/rsync.1.md
+++ b/rsync.1.md
@@ -4055,7 +4055,7 @@ file is included or excluded.
 
 # FORMAT STRINGS
 
-The following forrmat strings are supported for options accepting a `FORMAT`
+The following format strings are supported for options accepting a `FORMAT`
 parameter:
 
 0.  `%l` File length
@@ -4098,7 +4098,7 @@ parameter:
 
 # DAEMON FORMAT STRINGS
 
-The following forrmat strings are supported for options accepting a `FORMAT`
+The following format strings are supported for options accepting a `FORMAT`
 parameter when running as a daemon:
 
 0.  `%h` Client hostname (based on reverse lookup).


### PR DESCRIPTION
Hi all, I'd like to get some feedback on this potential change.

Today I was trying to figure out what formatting options `rsync` accepts via the manual page, and I didn't find what I was looking for. So instead I tried reading the code.

For the benefit of others who might run into this in the future, I decided to try documenting them in `rsync.1.md`.

Since I don't know the `rsync` code well, some of my descriptions might be wrong (or might need more detail on the subtleties). For example, I'm not sure how to properly describe `%b` or `%c` (there are some subtle differences in the logic depending on which is chosen, the `ITEM_TRANSFER`, and I wasn't sure what was meant by `initial_data_written` and `initial_data_read`). And I assumed from some of the context in the code that `%m` (the module name) had something to do with syslog, but I'm not positive about that (and I was further confused by `%P`, the "full module path", but my casual reading of the code didn't help me understand exactly what the "module" was for.

I also noticed that there was inconsistent usage of `FMT` vs. `FORMAT` in the manual page, but it seems to refer to the same functionality. So I tried to correct that, too.

Lastly, I don't have the tooling installed to generate the manual page from the Markdown file, so if this is something that would be good to move forward with, I'll look into installing that.