### PR TITLE
add ssl/tls key option

### DIFF
--- a/rsync-ssl
+++ b/rsync-ssl
@@ -74,7 +74,15 @@ function rsync_ssl_helper {
 	gnutls_cert_opt=""
     else
 	certopt="-cert$optsep$RSYNC_SSL_CERT"
-	gnutls_cert_opt="--x509keyfile=$RSYNC_SSL_CERT"
+	gnutls_cert_opt="--x509certfile=$RSYNC_SSL_CERT"
+    fi
+
+    if [[ -z "$RSYNC_SSL_KEY" ]]; then
+	keyopt=""
+	gnutls_key_opt=""
+    else
+	keyopt="-key$optsep$RSYNC_SSL_KEY"
+	gnutls_key_opt="--x509keyfile=$RSYNC_SSL_KEY"
     fi
 
     if [[ -z ${RSYNC_SSL_CA_CERT+x} ]]; then
@@ -129,9 +137,9 @@ function rsync_ssl_helper {
     fi
 
     if [[ $RSYNC_SSL_TYPE == openssl ]]; then
-	exec $RSYNC_SSL_OPENSSL s_client $caopt $certopt -quiet -verify_quiet -servername $hostname -verify_hostname $hostname -connect $hostname:$port
+	exec $RSYNC_SSL_OPENSSL s_client $caopt $certopt $keyopt -quiet -verify_quiet -servername $hostname -verify_hostname $hostname -connect $hostname:$port
     elif [[ $RSYNC_SSL_TYPE == gnutls ]]; then
-	exec $RSYNC_SSL_GNUTLS --logfile=/dev/null $gnutls_cert_opt $gnutls_opts $hostname:$port
+	exec $RSYNC_SSL_GNUTLS --logfile=/dev/null $gnutls_cert_opt $gnutls_key_opt $gnutls_opts $hostname:$port
     else
 	# devzero@web.de came up with this no-tmpfile calling syntax:
 	exec $RSYNC_SSL_STUNNEL -fd 10 11<&0 <<EOF 10<&0 0<&11 11<&-

--- a/rsync-ssl.1.md
+++ b/rsync-ssl.1.md
@@ -46,6 +46,8 @@ The ssl helper scripts are affected by the following environment variables:
     value to the helper script.)
 0.  `RSYNC_SSL_CERT` If specified, the value is a filename that contains a
     certificate to use for the connection.
+0.  `RSYNC_SSL_KEY` If specified, the value is a filename that contains a
+    key for the provided certificate to use for the connection.
 0.  `RSYNC_SSL_CA_CERT` If specified, the value is a filename that contains a
     certificate authority certificate that is used to validate the connection.
 0.  `RSYNC_SSL_OPENSSL` Specifies the openssl executable to run when the


### PR DESCRIPTION
as discussed [here](https://github.com/WayneD/rsync/issues/211) this PR adds an option to provide a key file to rsync-ssl