### PR TITLE
Fix spelling of 'nanosecond' ...

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -915,7 +915,7 @@
    hard-link it into place so that the upcoming replacement of the destination
    file will be atomic (for the normal, non-inplace logic).
 
- - Added the ability to synchronize nano-second modified times.
+ - Added the ability to synchronize nanosecond modified times.
 
  - Added a few more default suffixes for the `dont compress` settings.
 


### PR DESCRIPTION
... to make it easier to find when nanosecond support was added (3.1.0 / 28 Sep 2013)