### PR TITLE
Stop rrsync escaping restricted folder, by forcing --munge-links

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -36,6 +36,8 @@
  - Avoid a weird failure if you run a local copy with a (useless) `--rsh`
    option that contains a `V`.
 
+ - Stop rrsync escaping restricted folder, by forcing --munge-links.
+
 ### ENHANCEMENTS:
 
  - Use openssl's `-verify_hostname` option in the rsync-ssl script.

--- a/support/rrsync
+++ b/support/rrsync
@@ -13,6 +13,7 @@ use File::Glob ':glob';
 # of options if you want to disable any options that rsync accepts.
 use constant RSYNC => '/usr/bin/rsync';
 use constant LOGFILE => 'rrsync.log';
+use constant FORCE_OPT => ('--munge-links');
 
 my $Usage = <<EOM;
 Use 'command="$0 [-ro|-wo] SUBDIR"'
@@ -223,6 +224,8 @@ while ($command =~ /((?:[^\s\\]+|\\.[^\s\\]*)+)/g) {
   }
 }
 die "$0: invalid rsync-command syntax or options\n" if $in_options;
+
+push(@opts, FORCE_OPT);
 
 if ($subdir ne '/') {
     die "$0: do not use .. in any path!\n" if grep m{(^|/)\.\.(/|$)}, @args;


### PR DESCRIPTION
Fixes: https://bugzilla.samba.org/show_bug.cgi?id=11879

> fb102email-sambabugzilla 2016-04-28 15:52:40 UTC
>
> It is possible to escape rrsync restricted folder by syncing (using
> rsync -a ...) a symbolic link to the parent folder and then syncing with
> this symbolic link. [...]
>
> g.parrondo 2016-05-26 16:12:06 UTC
>
> Adding '--safe-links' or '--munge-links' on server side should fix this.