### PR TITLE
Always use number separator ',' and decimal point '.'

### DIFF
--- a/lib/compat.c
+++ b/lib/compat.c
@@ -22,25 +22,9 @@
 #include "rsync.h"
 #include "itypes.h"
 
-static char number_separator;
-
-char get_number_separator(void)
-{
-	if (!number_separator) {
-		char buf[32];
-		snprintf(buf, sizeof buf, "%f", 3.14);
-		if (strchr(buf, '.') != NULL)
-			number_separator = ',';
-		else
-			number_separator = '.';
-	}
-
-	return number_separator;
-}
-
 char get_decimal_point(void)
 {
-	return get_number_separator() == ',' ? '.' : ',';
+	return '.';
 }
 
 #ifndef HAVE_GETCWD
@@ -174,9 +158,6 @@ char *do_big_num(int64 num, int human_flag, const char *fract)
 	char *s;
 	int len, negated;
 
-	if (human_flag && !number_separator)
-		(void)get_number_separator();
-
 	n = (n + 1) % (sizeof bufs / sizeof bufs[0]);
 
 	if (human_flag > 1) {
@@ -230,7 +211,7 @@ char *do_big_num(int64 num, int human_flag, const char *fract)
 	while (num) {
 		if (human_flag) {
 			if (len == 3) {
-				*--s = number_separator;
+				*--s = ',';
 				len = 1;
 			} else
 				len++;


### PR DESCRIPTION
rsync’s code for detecting the number separator of the current locale is
currently broken, because rsync calls `setlocale(LC_CTYPE, "");` only,
where it should additionally call `setlocale(LC_NUMERIC, "");`.

Due to the missing `setlocale()` call, rsync already always uses
the number separator ',' and decimal point '.'.

This change makes that behavior permanent, so that downstream tools can
more easily parse rsync log output, for example to feed rsync stats into
monitoring systems.

This change follows the robustness principle design guideline:
“be conservative in what you send, be liberal in what you accept”,
see https://en.wikipedia.org/wiki/Robustness_principle

Here’s how I have verified that the missing setlocale() indeed results
in the same behavior:

Step 1: ensure our test environment is correctly set up so that numbers
are formatted with a different separator:
```
% LC_ALL=en_US.UTF-8 LANG=en_US.UTF-8 LC_CTYPE=en_US.UTF-8 LC_NUMERIC=en_US.UTF-8 perl -MPOSIX -E 'POSIX::setlocale(LC_NUMERIC, ""); use locale; $n = 5/2; printf "half five is %g\n", $n; '
half five is 2.5
% LC_ALL=de_DE.UTF-8 LANG=de_DE.UTF-8 LC_CTYPE=de_DE.UTF-8 LC_NUMERIC=de_DE.UTF-8 perl -MPOSIX -E 'POSIX::setlocale(LC_NUMERIC, ""); use locale; $n = 5/2; printf "half five is %g\n", $n; '
half five is 2,5
```
Step 2: run rsync with the same setup and observe its output does not change:
```
% mkdir -p /tmp/dummy && LC_ALL=de_DE.UTF-8 LANG=de_DE.UTF-8 LC_CTYPE=de_DE.UTF-8 LC_NUMERIC=de_DE.UTF-8 rsync -va ~/i3.github.io/docs/4.19.1 /tmp/dummy/
sending incremental file list

sent 1,590 bytes  received 18 bytes  3,216.00 bytes/sec
total size is 1,188,046  speedup is 738.83
% mkdir -p /tmp/dummy && LC_ALL=en_US.UTF-8 LANG=en_US.UTF-8 LC_CTYPE=en_US.UTF-8 LC_NUMERIC=en_US.UTF-8 rsync -va ~/i3.github.io/docs/4.19.1 /tmp/dummy/
sending incremental file list

sent 1,590 bytes  received 18 bytes  3,216.00 bytes/sec
total size is 1,188,046  speedup is 738.83
```