### PR TITLE
shell: test -a|o is not POSIX

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -200,7 +200,7 @@ configure.sh config.h.in: configure.ac aclocal.m4
 	else \
 	    echo "config.h.in has CHANGED."; \
 	fi
-	@if test -f configure.sh.old -o -f config.h.in.old; then \
+	@if test -f configure.sh.old || test -f config.h.in.old; then \
 	    if test "$(MAKECMDGOALS)" = reconfigure; then \
 		echo 'Continuing with "make reconfigure".'; \
 	    else \

--- a/configure.ac
+++ b/configure.ac
@@ -262,7 +262,7 @@ fi
 
 if test x"$enable_simd" != x"no"; then
     # For x86-64 SIMD, g++ >=5 or clang++ >=7 is required
-    if test x"$host_cpu" = x"x86_64" -o x"$host_cpu" = x"amd64"; then
+    if test x"$host_cpu" = x"x86_64" || test x"$host_cpu" = x"amd64"; then
 	AC_LANG(C++)
 	if test x"$host_cpu" = x"$build_cpu"; then
 	    AC_RUN_IFELSE([AC_LANG_PROGRAM([SIMD_X86_64_TEST],[[if (test_ssse3(42) != 42 || test_sse2(42) != 42 || test_avx2(42) != 42) exit(1);]])],
@@ -326,7 +326,7 @@ if test x"$enable_asm" = x""; then
 fi
 
 if test x"$enable_asm" != x"no"; then
-    if test x"$host_cpu" = x"x86_64" -o x"$host_cpu" = x"amd64"; then
+    if test x"$host_cpu" = x"x86_64" || test x"$host_cpu" = x"amd64"; then
 	ASM="$host_cpu"
     elif test x"$enable_asm" = x"yes"; then
         AC_MSG_RESULT(unavailable)
@@ -712,7 +712,7 @@ yes
 #endif],
 			rsync_cv_HAVE_GETADDR_DEFINES=yes,
 			rsync_cv_HAVE_GETADDR_DEFINES=no)])
-AS_IF([test x"$rsync_cv_HAVE_GETADDR_DEFINES" = x"yes" -a x"$ac_cv_type_struct_addrinfo" = x"yes"],[
+AS_IF([test x"$rsync_cv_HAVE_GETADDR_DEFINES" = x"yes" && test x"$ac_cv_type_struct_addrinfo" = x"yes"],[
 	# Tru64 UNIX has getaddrinfo() but has it renamed in libc as
 	# something else so we must include <netdb.h> to get the
 	# redefinition.
@@ -1384,7 +1384,7 @@ else
     esac
 fi
 
-if test x"$enable_acl_support" = x"no" -o x"$enable_xattr_support" = x"no" -o x"$enable_iconv" = x"no"; then
+if test x"$enable_acl_support" = x"no" || test x"$enable_xattr_support" = x"no" || test x"$enable_iconv" = x"no"; then
     AC_MSG_CHECKING([whether $CC supports -Wno-unused-parameter])
     OLD_CFLAGS="$CFLAGS"
     CFLAGS="$CFLAGS -Wno-unused-parameter"

--- a/install-sh
+++ b/install-sh
@@ -115,7 +115,7 @@ else
 # might cause directories to be created, which would be especially bad 
 # if $src (and thus $dsttmp) contains '*'.
 
-	if [ -f $src -o -d $src ]
+	if [ -f $src ] || [ -d $src ]
 	then
 		true
 	else

--- a/packaging/prep-auto-dir
+++ b/packaging/prep-auto-dir
@@ -13,7 +13,7 @@
 # run "make distclean" before creating the auto-build-save dir.
 
 auto_top='auto-build-save'
-if test -d $auto_top -a -d .git; then
+if test -d $auto_top && test -d .git; then
     desired_branch=`git rev-parse --abbrev-ref HEAD | tr / %`
     if test "$desired_branch" = HEAD; then
 	echo "ERROR: switch to the right build dir manually when in detached HEAD mode." 1>&2

--- a/prepare-source
+++ b/prepare-source
@@ -32,7 +32,7 @@ if test "$dir" != '.'; then
 	fi
     done
     for fn in configure.sh config.h.in aclocal.m4; do
-	test ! -f $fn -a -f "$dir/$fn" && cp -p "$dir/$fn" $fn
+	test ! -f $fn && test -f "$dir/$fn" && cp -p "$dir/$fn" $fn
     done
 fi
 

--- a/runtests.sh
+++ b/runtests.sh
@@ -155,7 +155,7 @@ if test x"$TOOLDIR" = x; then
     TOOLDIR=`pwd`
 fi
 srcdir=`dirname $0`
-if test x"$srcdir" = x -o x"$srcdir" = x.; then
+if test x"$srcdir" = x || test x"$srcdir" = x.; then
     srcdir="$TOOLDIR"
 fi
 if test x"$rsync_bin" = x; then
@@ -288,7 +288,7 @@ for testscript in $suitedir/$whichtests; do
     result=$?
     set -e
 
-    if [ "x$always_log" = xyes -o \( $result != 0 -a $result != 77 -a $result != 78 \) ]
+    if [ "x$always_log" = xyes ] || ( [ $result != 0 ] && [ $result != 77 ] && [ $result != 78 ] )
     then
 	echo "----- $testbase log follows"
 	cat "$scratchdir/test.log"
@@ -336,7 +336,7 @@ echo "      $passed passed"
 [ "$failed" -gt 0 ]  && echo "      $failed failed"
 [ "$skipped" -gt 0 ] && echo "      $skipped skipped"
 [ "$missing" -gt 0 ] && echo "      $missing missing"
-if [ "$full_run" = yes -a "$expect_skipped" != IGNORE ]; then
+if [ "$full_run" = yes ] && [ "$expect_skipped" != IGNORE ]; then
     skipped_list=`echo "$skipped_list" | sed 's/^,//'`
     echo "----- skipped results:"
     echo "      expected: $expect_skipped"
@@ -353,7 +353,7 @@ echo '------------------------------------------------------------'
 # because -e is set.
 
 result=`expr $failed + $missing || true`
-if [ "$result" = 0 -a "$skipped_list" != "$expect_skipped" ]; then
+if [ "$result" = 0 ] && [ "$skipped_list" != "$expect_skipped" ]; then
     result=1
 fi
 echo "overall result is $result"

--- a/testsuite/chmod-temp-dir.test
+++ b/testsuite/chmod-temp-dir.test
@@ -17,7 +17,7 @@ sdev=`$TOOLDIR/getfsdev $scratchdir`
 tdev=$sdev
 
 for tmpdir2 in "${RSYNC_TEST_TMP:-/override-tmp-not-specified}" /run/shm /var/tmp /tmp; do
-    [ -d "$tmpdir2" -a -w "$tmpdir2" ] || continue
+    [ -d "$tmpdir2" ] && [ -w "$tmpdir2" ] || continue
     tdev=`$TOOLDIR/getfsdev "$tmpdir2"`
     [ x$sdev != x$tdev ] && break
 done

--- a/testsuite/rsync.fns
+++ b/testsuite/rsync.fns
@@ -65,7 +65,7 @@ set_cp_destdir() {
 # even if the copy rounded microsecond times on the destination file.
 cp_touch() {
     cp_p "${@}"
-    if test $# -gt 2 -o -d "$2"; then
+    if test $# -gt 2 || test -d "$2"; then
 	set_cp_destdir "${@}" # sets destdir var
 	while test $# -gt 1; do
 	    destname="$destdir/`basename $1`"


### PR DESCRIPTION
I faced `test: too many arguments` when building using [sbase](https://core.suckless.org/sbase/).
This is due to a non-POSIX syntax `test ... -a ...` and `test … -o …`.

> The XSI extensions specifying the -a and -o binary primaries and the '(' and ')' operators have been marked obsolescent.

https://pubs.opengroup.org/onlinepubs/9699919799/utilities/test.html