### PR TITLE
configure.sh:4912: checking whether to enable SIMD optimizations // configure.sh:4936: error: cannot run test program while cross compiling

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -264,7 +264,7 @@ if test x"$enable_simd" != x"no"; then
     # For x86-64 SIMD, g++ >=5 or clang++ >=7 is required
     if test x"$host_cpu" = x"x86_64" || test x"$host_cpu" = x"amd64"; then
 	AC_LANG(C++)
-	if test x"$host_cpu" = x"$build_cpu"; then
+	if test x"$host" = x"$build"; then
 	    AC_RUN_IFELSE([AC_LANG_PROGRAM([SIMD_X86_64_TEST],[[if (test_ssse3(42) != 42 || test_sse2(42) != 42 || test_avx2(42) != 42) exit(1);]])],
 		[CXX_OK=yes],[CXX_OK=no])
 	else


### PR DESCRIPTION
Hello, thank you for fixing cross compilation issues. We need just one [quick improvement for cross compilation detection](https://bugs.gentoo.org/732084).

```
$host = x86_64-pc-linux-gnu
$build = x86_64-unknown-linux-gnu
```

This configuration means cross compilation, so I can suggest comparison just between `$host` and `$build`.