### PR TITLE
Quotation for usermap and groupmap arguments

### DIFF
--- a/options.c
+++ b/options.c
@@ -2783,13 +2783,13 @@ void server_options(char **args, int *argc_p)
 
 	if (am_sender) {
 		if (usermap) {
-			if (asprintf(&arg, "--usermap=%s", usermap) < 0)
+			if (asprintf(&arg, "--usermap='%s'", usermap) < 0)
 				goto oom;
 			args[ac++] = arg;
 		}
 
 		if (groupmap) {
-			if (asprintf(&arg, "--groupmap=%s", groupmap) < 0)
+			if (asprintf(&arg, "--groupmap='%s'", groupmap) < 0)
 				goto oom;
 			args[ac++] = arg;
 		}


### PR DESCRIPTION
Since wildcards are being used as parameters, shells like Fish try to expand this and fail. The single quotes prevent them from doing so and still work with Bash.

Fixes #272