### PR TITLE
add libcheck unit tests for wildmatch

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -54,9 +54,13 @@ OBJS=$(OBJS1) $(OBJS2) $(OBJS3) $(DAEMON_OBJ) $(LIBOBJ) @BUILD_ZLIB@ @BUILD_POPT
 
 TLS_OBJ = tls.o syscall.o util2.o t_stub.o lib/compat.o lib/snprintf.o lib/permstring.o lib/sysxattrs.o @BUILD_POPT@
 
+# Programs we must have to run unit tests
+UNIT_EXES=check/wildtest$(EXEEXT)
+
 # Programs we must have to run the test cases
 CHECK_PROGS = rsync$(EXEEXT) tls$(EXEEXT) getgroups$(EXEEXT) getfsdev$(EXEEXT) \
-	testrun$(EXEEXT) trimslash$(EXEEXT) t_unsafe$(EXEEXT) wildtest$(EXEEXT)
+	testrun$(EXEEXT) trimslash$(EXEEXT) t_unsafe$(EXEEXT) wildtest$(EXEEXT) \
+	$(UNIT_EXES)
 
 CHECK_SYMLINKS = testsuite/chown-fake.test testsuite/devices-fake.test testsuite/xattrs-hlink.test
 
@@ -316,15 +320,15 @@ test: check
 # might lose in the future where POSIX diverges from old sh.
 
 .PHONY: check
-check: all $(CHECK_PROGS) $(CHECK_SYMLINKS)
+check: all @RSYNC_CHECK_UNIT@ $(CHECK_PROGS) $(CHECK_SYMLINKS)
 	rsync_bin=`pwd`/rsync$(EXEEXT) $(srcdir)/runtests.sh
 
 .PHONY: check29
-check29: all $(CHECK_PROGS) $(CHECK_SYMLINKS)
+check29: all @RSYNC_CHECK_UNIT@ $(CHECK_PROGS) $(CHECK_SYMLINKS)
 	rsync_bin=`pwd`/rsync$(EXEEXT) $(srcdir)/runtests.sh --protocol=29
 
 .PHONY: check30
-check30: all $(CHECK_PROGS) $(CHECK_SYMLINKS)
+check30: all @RSYNC_CHECK_UNIT@ $(CHECK_PROGS) $(CHECK_SYMLINKS)
 	rsync_bin=`pwd`/rsync$(EXEEXT) $(srcdir)/runtests.sh --protocol=30
 
 wildtest.o: wildtest.c t_stub.o lib/wildmatch.c rsync.h config.h
@@ -339,6 +343,15 @@ testsuite/devices-fake.test:
 
 testsuite/xattrs-hlink.test:
 	ln -s xattrs.test $(srcdir)/testsuite/xattrs-hlink.test
+
+.PHONY: check_unit
+check_unit: $(UNIT_EXES)
+	@for unit in $(UNIT_EXES); do \
+	  $${unit} ;\
+	done
+
+check/wildtest$(EXEEXT): check/wildtest.c wildtest.c lib/wildmatch.c rsync.h config.h Makefile
+	$(CC) -ggdb $(CFLAGS) $(LDFLAGS) -I.. -I. -Wno-unused-parameter -Wno-unused-function -o $@ check/wildtest.c $(LIBS) -lcheck
 
 # This does *not* depend on building or installing: you can use it to
 # check a version installed from a binary or some other source tree,

--- a/Makefile.in
+++ b/Makefile.in
@@ -59,8 +59,7 @@ UNIT_EXES=check/wildtest$(EXEEXT)
 
 # Programs we must have to run the test cases
 CHECK_PROGS = rsync$(EXEEXT) tls$(EXEEXT) getgroups$(EXEEXT) getfsdev$(EXEEXT) \
-	testrun$(EXEEXT) trimslash$(EXEEXT) t_unsafe$(EXEEXT) wildtest$(EXEEXT) \
-	$(UNIT_EXES)
+	testrun$(EXEEXT) trimslash$(EXEEXT) t_unsafe$(EXEEXT) wildtest$(EXEEXT)
 
 CHECK_SYMLINKS = testsuite/chown-fake.test testsuite/devices-fake.test testsuite/xattrs-hlink.test
 

--- a/check/iwildtest.txt
+++ b/check/iwildtest.txt
@@ -1,0 +1,165 @@
+# Input is in the following format (all items white-space separated):
+#
+# The first two items are 1 or 0 indicating if the wildmat call is expected to
+# succeed and if fnmatch works the same way as wildmat, respectively.  After
+# that is a text string for the match, and a pattern string.  Strings can be
+# quoted (if desired) in either double or single quotes, as well as backticks.
+#
+# MATCH FNMATCH_SAME "text to match" 'pattern to use'
+
+# Basic wildmat features
+1 1 foo			foo
+0 1 foo			bar
+1 1 ''			""
+1 1 foo			???
+0 1 foo			??
+1 1 foo			*
+1 1 foo			f*
+0 1 foo			*f
+1 1 foo			*foo*
+1 1 foobar		*ob*a*r*
+1 1 aaaaaaabababab	*ab
+1 1 foo*		foo\*
+0 1 foobar		foo\*bar
+1 1 f\oo		f\\oo
+1 1 ball		*[al]?
+0 1 ten			[ten]
+1 1 ten			**[!te]
+0 1 ten			**[!ten]
+1 1 ten			t[a-g]n
+0 1 ten			t[!a-g]n
+1 1 ton			t[!a-g]n
+1 1 ton			t[^a-g]n
+1 1 a]b			a[]]b
+1 1 a-b			a[]-]b
+1 1 a]b			a[]-]b
+0 1 aab			a[]-]b
+1 1 aab			a[]a-]b
+1 1 ]			]
+
+# Extended slash-matching features
+0 1 foo/baz/bar		foo*bar
+1 1 foo/baz/bar		foo**bar
+0 1 foo/bar		foo?bar
+0 1 foo/bar		foo[/]bar
+0 1 foo/bar		f[^eiu][^eiu][^eiu][^eiu][^eiu]r
+1 1 foo-bar		f[^eiu][^eiu][^eiu][^eiu][^eiu]r
+0 1 foo			**/foo
+1 1 /foo		**/foo
+1 1 bar/baz/foo		**/foo
+0 1 bar/baz/foo		*/foo
+0 0 foo/bar/baz		**/bar*
+1 1 deep/foo/bar/baz	**/bar/*
+0 1 deep/foo/bar/baz/	**/bar/*
+1 1 deep/foo/bar/baz/	**/bar/**
+0 1 deep/foo/bar	**/bar/*
+1 1 deep/foo/bar/	**/bar/**
+1 1 foo/bar/baz		**/bar**
+1 1 foo/bar/baz/x	*/bar/**
+0 0 deep/foo/bar/baz/x	*/bar/**
+1 1 deep/foo/bar/baz/x	**/bar/*/*
+
+# Various additional tests
+0 1 acrt		a[c-c]st
+1 1 acrt		a[c-c]rt
+0 1 ]			[!]-]
+1 1 a			[!]-]
+0 1 ''			\
+0 1 \			\
+0 1 /\			*/\
+1 1 /\			*/\\
+1 1 foo			foo
+1 1 @foo		@foo
+0 1 foo			@foo
+1 1 [ab]		\[ab]
+1 1 [ab]		[[]ab]
+1 1 [ab]		[[:]ab]
+0 1 [ab]		[[::]ab]
+1 1 [ab]		[[:digit]ab]
+1 1 [ab]		[\[:]ab]
+1 1 ?a?b		\??\?b
+1 1 abc			\a\b\c
+0 1 foo			''
+1 1 foo/bar/baz/to	**/t[o]
+
+# Character class tests
+#1 1 a1B		[[:alpha:]][[:digit:]][[:upper:]]
+0 1 a		[[:digit:][:upper:][:space:]]
+#1 1 A		[[:digit:][:upper:][:space:]]
+1 1 1		[[:digit:][:upper:][:space:]]
+0 1 1		[[:digit:][:upper:][:spaci:]]
+1 1 ' '		[[:digit:][:upper:][:space:]]
+0 1 .		[[:digit:][:upper:][:space:]]
+1 1 .		[[:digit:][:punct:][:space:]]
+1 1 5		[[:xdigit:]]
+1 1 f		[[:xdigit:]]
+1 1 D		[[:xdigit:]]
+1 1 _		[[:alnum:][:alpha:][:blank:][:cntrl:][:digit:][:graph:][:lower:][:print:][:punct:][:space:][:upper:][:xdigit:]]
+#1 1 …		[^[:alnum:][:alpha:][:blank:][:cntrl:][:digit:][:graph:][:lower:][:print:][:punct:][:space:][:upper:][:xdigit:]]
+1 1 		[^[:alnum:][:alpha:][:blank:][:digit:][:graph:][:lower:][:print:][:punct:][:space:][:upper:][:xdigit:]]
+1 1 .		[^[:alnum:][:alpha:][:blank:][:cntrl:][:digit:][:lower:][:space:][:upper:][:xdigit:]]
+1 1 5		[a-c[:digit:]x-z]
+1 1 b		[a-c[:digit:]x-z]
+1 1 y		[a-c[:digit:]x-z]
+0 1 q		[a-c[:digit:]x-z]
+
+# Additional tests, including some malformed wildmats
+1 1 ]		[\\-^]
+0 1 [		[\\-^]
+1 1 -		[\-_]
+1 1 ]		[\]]
+0 1 \]		[\]]
+0 1 \		[\]]
+0 1 ab		a[]b
+0 1 a[]b	a[]b
+0 1 ab[		ab[
+0 1 ab		[!
+0 1 ab		[-
+1 1 -		[-]
+0 1 -		[a-
+0 1 -		[!a-
+1 1 -		[--A]
+1 1 5		[--A]
+1 1 ' '		'[ --]'
+1 1 $		'[ --]'
+1 1 -		'[ --]'
+0 1 0		'[ --]'
+1 1 -		[---]
+1 1 -		[------]
+0 1 j		[a-e-n]
+1 1 -		[a-e-n]
+1 1 a		[!------]
+0 1 [		[]-a]
+1 1 ^		[]-a]
+0 1 ^		[!]-a]
+1 1 [		[!]-a]
+1 1 ^		[a^bc]
+1 1 -b]		[a-]b]
+0 1 \		[\]
+1 1 \		[\\]
+0 1 \		[!\\]
+#1 1 G		[A-\\]
+0 1 aaabbb	b*a
+0 1 aabcaa	*ba*
+1 1 ,		[,]
+1 1 ,		[\\,]
+1 1 \		[\\,]
+1 1 -		[,-.]
+0 1 +		[,-.]
+0 1 -.]		[,-.]
+1 1 2		[\1-\3]
+1 1 3		[\1-\3]
+0 1 4		[\1-\3]
+1 1 \		[[-\]]
+1 1 [		[[-\]]
+1 1 ]		[[-\]]
+0 1 -		[[-\]]
+
+# Test recursion and the abort code (use "wildtest -i" to see iteration counts)
+1 1 -adobe-courier-bold-o-normal--12-120-75-75-m-70-iso8859-1	-*-*-*-*-*-*-12-*-*-*-m-*-*-*
+0 1 -adobe-courier-bold-o-normal--12-120-75-75-X-70-iso8859-1	-*-*-*-*-*-*-12-*-*-*-m-*-*-*
+0 1 -adobe-courier-bold-o-normal--12-120-75-75-/-70-iso8859-1	-*-*-*-*-*-*-12-*-*-*-m-*-*-*
+1 1 /adobe/courier/bold/o/normal//12/120/75/75/m/70/iso8859/1	/*/*/*/*/*/*/12/*/*/*/m/*/*/*
+0 1 /adobe/courier/bold/o/normal//12/120/75/75/X/70/iso8859/1	/*/*/*/*/*/*/12/*/*/*/m/*/*/*
+1 1 abcd/abcdefg/abcdefghijk/abcdefghijklmnop.txt		**/*a*b*g*n*t
+0 1 abcd/abcdefg/abcdefghijk/abcdefghijklmnop.txtz		**/*a*b*g*n*t

--- a/check/wildtest.c
+++ b/check/wildtest.c
@@ -39,6 +39,41 @@ START_TEST(wildtest_legacyfile) {
     ck_assert_int_eq(line, 165);
 }
 
+START_TEST(wildtest_insensitive) {
+    FILE *fp = NULL;
+
+    char *file = "./check/iwildtest.txt";
+
+    char buf[2048], *string[2], *end[2];
+    int flag[2];
+
+    if ((fp = fopen(file, "r")) == NULL) {
+        ck_assert_msg(fp != NULL, "Unable to open %s", file);
+        return;
+    }
+
+    int line = 0;
+    while (fgets(buf, sizeof buf, fp)) {
+        line++;
+
+        if (parse_line(&file, line, buf, flag, end, string) == 0)
+            continue;
+
+        char *text = string[0];
+        char *pattern = string[1];
+        bool matches = flag[0];
+
+        bool matched = iwildmatch(pattern, text);
+
+        ck_assert_msg(
+            matched == matches,
+            "wildmatch failure on line %d:\n  %s\n  %s\n  expected %s match\n",
+            line, text, pattern, matches ? "a" : "NO");
+    }
+
+    ck_assert_int_eq(line, 165);
+}
+
 Suite *wildtest_suite() {
     Suite *s;
     TCase *tcase;
@@ -46,6 +81,10 @@ Suite *wildtest_suite() {
     s = suite_create("wildtest");
     tcase = tcase_create("wildtest - wildtest.txt");
     tcase_add_test(tcase, wildtest_legacyfile);
+    suite_add_tcase(s, tcase);
+
+    tcase = tcase_create("wildtest - iwildtest.txt (insensitive)");
+    tcase_add_test(tcase, wildtest_insensitive);
     suite_add_tcase(s, tcase);
 
     return s;

--- a/check/wildtest.c
+++ b/check/wildtest.c
@@ -205,6 +205,20 @@ START_TEST(wildtest_exploded) {
     ck_assert_int_eq(line, 165);
 }
 
+START_TEST(wildtest_doliteral) {
+    char* nulls[] = { NULL, NULL, NULL, NULL };
+    char* abc[] = { "ab", "", "c", NULL };
+    char* abcd[] = { "ab", "", "c", "d", NULL };
+
+    ck_assert_int_eq(doliteral((uchar *)"foo", (uchar *)"foo", (const uchar * const *)nulls), 1);
+    ck_assert_int_eq(doliteral((uchar *)"foo", (uchar *)"roo", (const uchar * const *)nulls), 0);
+
+    ck_assert_int_eq(doliteral((uchar *)"fooabc", (uchar *)"foo", (const uchar * const *)abc), 1);
+
+    ck_assert_int_eq(doliteral((uchar *)"fooabcd", (uchar *)"foo", (const uchar * const *)abc), 0);
+    ck_assert_int_eq(doliteral((uchar *)"fooabc", (uchar *)"foo", (const uchar * const *)abcd), 0);
+}
+
 Suite *wildtest_suite() {
     Suite *s;
     TCase *tcase;

--- a/check/wildtest.c
+++ b/check/wildtest.c
@@ -7,7 +7,7 @@
 START_TEST(wildtest_legacyfile) {
     FILE *fp = NULL;
 
-    char *file = "./wildtest.txt";
+    char *file = "./check/wildtest.txt";
 
     char buf[2048], *string[2], *end[2];
     int flag[2];
@@ -37,7 +37,6 @@ START_TEST(wildtest_legacyfile) {
     }
 
     fclose(fp);
-    ck_assert_int_eq(line, 165);
 }
 
 START_TEST(wildtest_insensitive) {
@@ -112,7 +111,6 @@ START_TEST(wildtest_fnmatch) {
     }
 
     fclose(fp);
-    ck_assert_int_eq(line, 165);
 }
 
 struct mode {

--- a/check/wildtest.c
+++ b/check/wildtest.c
@@ -1,6 +1,43 @@
+#define RSYNC_WILDTEST_NO_MAIN 1
+#include "../wildtest.c"
+
 #include <check.h>
 
-START_TEST(wildtest_legacyfile) { ck_assert_int_eq(0, 0); }
+START_TEST(wildtest_legacyfile) {
+    FILE *fp = NULL;
+
+    char *file = "./wildtest.txt";
+
+    char buf[2048], *string[2], *end[2];
+    int flag[2];
+
+    if ((fp = fopen(file, "r")) == NULL) {
+        ck_assert_msg(fp != NULL, "Unable to open %s", file);
+        return;
+    }
+
+    int line = 0;
+    while (fgets(buf, sizeof buf, fp)) {
+        line++;
+
+        if (parse_line(&file, line, buf, flag, end, string) == 0)
+            continue;
+
+        char *text = string[0];
+        char *pattern = string[1];
+        bool matches = flag[0];
+
+        bool matched = wildmatch(pattern, text);
+
+        ck_assert_msg(
+            matched == matches,
+            "wildmatch failure on line %d:\n  %s\n  %s\n  expected %s match\n",
+            line, text, pattern, matches ? "a" : "NO");
+    }
+
+    fclose(fp);
+    ck_assert_int_eq(line, 165);
+}
 
 Suite *wildtest_suite() {
     Suite *s;

--- a/check/wildtest.c
+++ b/check/wildtest.c
@@ -219,6 +219,33 @@ START_TEST(wildtest_doliteral) {
     ck_assert_int_eq(doliteral((uchar *)"fooabc", (uchar *)"foo", (const uchar * const *)abcd), 0);
 }
 
+START_TEST(wildtest_trailing_N_elements) {
+    char path1[] = "foo/bar/baz/bletch";
+    char * path1_bletch = path1+12;
+
+    const char * const texts[] = { path1, NULL };
+    const uchar * const * a = (const uchar*const*)texts;
+
+    ck_assert_ptr_eq(trailing_N_elements(&a, 1), path1_bletch);
+
+    char path2_a[] = "foobarbaz";
+    char path2_b[] = "";
+
+    const char * const texts_2[] = { path2_a, path2_b, NULL };
+    a = (const uchar*const*)texts_2;
+
+    const uchar *result = trailing_N_elements(&a, 1);
+    ck_assert_str_eq((const char *)result, path2_a);
+
+    char path3_a[] = "foobarbaz";
+    char path3_b[] = "";
+
+    const char * const texts_3[] = { path3_a, path3_b, NULL };
+    a = (const uchar*const*)texts_3;
+
+    result = trailing_N_elements(&a, 3);
+    ck_assert_ptr_eq(result, NULL);
+}
 Suite *wildtest_suite() {
     Suite *s;
     TCase *tcase;

--- a/check/wildtest.c
+++ b/check/wildtest.c
@@ -272,6 +272,39 @@ START_TEST(wildtest_array) {
     ck_assert_int_eq(wildmatch_array("bletch/**", texts_5, -1), 0);
 }
 
+START_TEST(wildtest_star) {
+    int result;
+
+    const char * const texts[] = { "f/", "/b/b/f/", "", "bab", NULL };
+    result = dowild((const uchar *)"*/a/**/bab", (const uchar *)"f/", (const uchar * const *)texts);
+    ck_assert_int_eq(result, ABORT_TO_STARSTAR);
+
+    const char * const texts_2[] = { "f/", "/b/b/f/", "", "bab", NULL };
+    result = dowild((const uchar *)"*/a/**/babx", (const uchar *)"f/", (const uchar * const *)texts_2);
+    ck_assert_int_eq(result, ABORT_TO_STARSTAR);
+
+    const char * const texts_3[] = { "", NULL };
+    result = dowild((const uchar *)"*", (const uchar *)"", (const uchar * const *)texts_3);
+    ck_assert_int_eq(result, TRUE);
+
+    result = dowild((const uchar *)"b", (const uchar *)"", (const uchar * const *)texts_3);
+    ck_assert_int_eq(result, ABORT_ALL);
+
+    result = wildmatch_array("b", texts_3, -1);
+    ck_assert_int_eq(result, FALSE);
+
+    const char * const texts_4[] = { "f/", "babx", "/", "", NULL };
+    result = wildmatch_array("**/babx", texts_4, -1);
+    ck_assert_int_eq(result, FALSE);
+
+    const char * const texts_5[] = { "f/", "a/", "a/", "babx", "/", "", NULL };
+    result = wildmatch_array("*/a/**/babx", texts_5, -1);
+    ck_assert_int_eq(result, FALSE);
+
+    const char * const texts_6[] = { "foo/a/foo/ooo", NULL };
+    ck_assert_int_eq(wildmatch_array("*/foo/**/oo", texts_6, -1), 0);
+}
+
 START_TEST(test_litmatch_array) {
     const char * const texts[] = { "foo/", "bar", NULL };
 
@@ -315,6 +348,10 @@ Suite *wildtest_suite() {
 
     tcase = tcase_create("wildtest_array");
     tcase_add_test(tcase, wildtest_array);
+    suite_add_tcase(s, tcase);
+
+    tcase = tcase_create("wildtest_star");
+    tcase_add_test(tcase, wildtest_star);
     suite_add_tcase(s, tcase);
 
     tcase = tcase_create("litmatch_array");

--- a/check/wildtest.c
+++ b/check/wildtest.c
@@ -301,6 +301,10 @@ Suite *wildtest_suite() {
     tcase_add_test(tcase, wildtest_trailing_N_elements);
     suite_add_tcase(s, tcase);
 
+    tcase = tcase_create("wildtest_array");
+    tcase_add_test(tcase, wildtest_array);
+    suite_add_tcase(s, tcase);
+
     return s;
 }
 

--- a/check/wildtest.c
+++ b/check/wildtest.c
@@ -246,6 +246,32 @@ START_TEST(wildtest_trailing_N_elements) {
     result = trailing_N_elements(&a, 3);
     ck_assert_ptr_eq(result, NULL);
 }
+
+START_TEST(wildtest_array) {
+    const char * const texts[] = { "foo", "bar", NULL };
+
+    ck_assert_int_eq(wildmatch_array("foobar", texts, 0), 1);
+    ck_assert_int_eq(wildmatch_array("foobaz", texts, 0), 0);
+    ck_assert_int_eq(wildmatch_array("fobbar", texts, 0), 0);
+
+    ck_assert_int_eq(wildmatch_array("foobar", texts, 2), 0);
+
+    const char * const texts_2[] = { "foo/", "bar/", "baz/", "bletch", NULL };
+    ck_assert_int_eq(wildmatch_array("baz/bletch", texts_2, 2), 1);
+    ck_assert_int_eq(wildmatch_array("*/bletch", texts_2, 2), 1);
+
+    const char * const texts_3[] = { "foo/", "bar/", "baz/", "bletch", NULL };
+    ck_assert_int_eq(wildmatch_array("bar/baz/bletch", texts_3, -1), 1);
+    ck_assert_int_eq(wildmatch_array("**/baz/*", texts_3, -1), 1);
+
+    const char * const texts_4[] = { "foo/", "bar/", "", "", "", "baz/", "bletch", "", "", NULL };
+    ck_assert_int_eq(wildmatch_array("bar/**/bletch", texts_4, -1), 1);
+    ck_assert_int_eq(wildmatch_array("baz/bletch/**", texts_4, -1), 0);
+
+    const char * const texts_5[] = { "foo", NULL };
+    ck_assert_int_eq(wildmatch_array("bletch/**", texts_5, -1), 0);
+}
+
 Suite *wildtest_suite() {
     Suite *s;
     TCase *tcase;

--- a/check/wildtest.c
+++ b/check/wildtest.c
@@ -272,6 +272,18 @@ START_TEST(wildtest_array) {
     ck_assert_int_eq(wildmatch_array("bletch/**", texts_5, -1), 0);
 }
 
+START_TEST(test_litmatch_array) {
+    const char * const texts[] = { "foo/", "bar", NULL };
+
+    ck_assert_int_eq(litmatch_array("bar", texts, 1), 1);
+    ck_assert_int_eq(litmatch_array("foo/bar", texts, 0), 1);
+    ck_assert_int_eq(litmatch_array("foo/baz", texts, 0), 0);
+
+    const char * const texts_2[] = { NULL };
+
+    ck_assert_int_eq(litmatch_array("foo/bar", texts_2, -1), 0);
+}
+
 Suite *wildtest_suite() {
     Suite *s;
     TCase *tcase;
@@ -303,6 +315,10 @@ Suite *wildtest_suite() {
 
     tcase = tcase_create("wildtest_array");
     tcase_add_test(tcase, wildtest_array);
+    suite_add_tcase(s, tcase);
+
+    tcase = tcase_create("litmatch_array");
+    tcase_add_test(tcase, test_litmatch_array);
     suite_add_tcase(s, tcase);
 
     return s;

--- a/check/wildtest.c
+++ b/check/wildtest.c
@@ -297,6 +297,10 @@ Suite *wildtest_suite() {
     tcase_add_test(tcase, wildtest_doliteral);
     suite_add_tcase(s, tcase);
 
+    tcase = tcase_create("wildtest trailing_N_elements");
+    tcase_add_test(tcase, wildtest_trailing_N_elements);
+    suite_add_tcase(s, tcase);
+
     return s;
 }
 

--- a/check/wildtest.c
+++ b/check/wildtest.c
@@ -293,6 +293,10 @@ Suite *wildtest_suite() {
     tcase_add_test(tcase, wildtest_exploded);
     suite_add_tcase(s, tcase);
 
+    tcase = tcase_create("wildtest doliteral");
+    tcase_add_test(tcase, wildtest_doliteral);
+    suite_add_tcase(s, tcase);
+
     return s;
 }
 

--- a/check/wildtest.c
+++ b/check/wildtest.c
@@ -148,19 +148,19 @@ static void explode(const char *text, char *buf, char **texts,
     int empties_mod = mode->empties_mod;
 
     if (empty_at_start)
-	texts[ndx++] = "";
+        texts[ndx++] = "";
     /* An empty string must turn into at least one empty array item. */
     while (1) {
-	texts[ndx] = buf + ndx * (explode_mod + 1);
-	strlcpy(texts[ndx++], text + pos, explode_mod + 1);
-	if (pos + explode_mod >= len)
-	    break;
-	pos += explode_mod;
-	if (!(++cnt % empties_mod))
-	    texts[ndx++] = "";
+        texts[ndx] = buf + ndx * (explode_mod + 1);
+        strlcpy(texts[ndx++], text + pos, explode_mod + 1);
+        if (pos + explode_mod >= len)
+            break;
+        pos += explode_mod;
+        if (!(++cnt % empties_mod))
+            texts[ndx++] = "";
     }
     if (empty_at_end)
-	texts[ndx++] = "";
+        texts[ndx++] = "";
     texts[ndx] = NULL;
 }
 

--- a/check/wildtest.c
+++ b/check/wildtest.c
@@ -2,6 +2,7 @@
 #include "../wildtest.c"
 
 #include <check.h>
+#include <fnmatch.h>
 
 START_TEST(wildtest_legacyfile) {
     FILE *fp = NULL;
@@ -74,6 +75,46 @@ START_TEST(wildtest_insensitive) {
     ck_assert_int_eq(line, 165);
 }
 
+START_TEST(wildtest_fnmatch) {
+    FILE *fp = NULL;
+
+    char *file = "./check/wildtest_fnmatch.txt";
+
+    char buf[2048], *string[2], *end[2];
+    int flag[2];
+
+    if ((fp = fopen(file, "r")) == NULL) {
+        ck_assert_msg(fp != NULL, "Unable to open %s", file);
+        return;
+    }
+
+    int line = 0;
+    while (fgets(buf, sizeof buf, fp)) {
+        line++;
+
+        if (parse_line(&file, line, buf, flag, end, string) == 0)
+            continue;
+
+        char *text = string[0];
+        char *pattern = string[1];
+        bool matches = flag[0];
+        bool same_as_fnmatch = flag[1];
+        bool fn_matches = (matches ^ !same_as_fnmatch);
+
+        int flags = strstr(pattern, "**") ? 0 : FNM_PATHNAME;
+
+        bool fn_matched = !fnmatch(pattern, text, flags);
+
+        ck_assert_msg(fn_matched == fn_matches,
+                      "fnmatch disagreement on line %d:\n  %s\n  %s\n  "
+                      "expected %s match\n",
+                      line, text, pattern, fn_matches ? "a" : "NO");
+    }
+
+    fclose(fp);
+    ck_assert_int_eq(line, 165);
+}
+
 Suite *wildtest_suite() {
     Suite *s;
     TCase *tcase;
@@ -85,6 +126,10 @@ Suite *wildtest_suite() {
 
     tcase = tcase_create("wildtest - iwildtest.txt (insensitive)");
     tcase_add_test(tcase, wildtest_insensitive);
+    suite_add_tcase(s, tcase);
+
+    tcase = tcase_create("wildtest (fnmatch) - wildtest_fnmatch.txt");
+    tcase_add_test(tcase, wildtest_fnmatch);
     suite_add_tcase(s, tcase);
 
     return s;

--- a/check/wildtest.c
+++ b/check/wildtest.c
@@ -1,0 +1,28 @@
+#include <check.h>
+
+START_TEST(wildtest_legacyfile) { ck_assert_int_eq(0, 0); }
+
+Suite *wildtest_suite() {
+    Suite *s;
+    TCase *tcase;
+
+    s = suite_create("wildtest");
+    tcase = tcase_create("wildtest - wildtest.txt");
+    tcase_add_test(tcase, wildtest_legacyfile);
+    suite_add_tcase(s, tcase);
+
+    return s;
+}
+
+int main(int _argc, char **_argv) {
+    int number_failed;
+    SRunner *sr;
+
+    sr = srunner_create(NULL);
+    srunner_add_suite(sr, wildtest_suite());
+
+    srunner_run_all(sr, CK_ENV);
+    number_failed = srunner_ntests_failed(sr);
+    srunner_free(sr);
+    return (number_failed != 0);
+}

--- a/check/wildtest_fnmatch.txt
+++ b/check/wildtest_fnmatch.txt
@@ -1,0 +1,165 @@
+# Input is in the following format (all items white-space separated):
+#
+# The first two items are 1 or 0 indicating if the wildmat call is expected to
+# succeed and if fnmatch works the same way as wildmat, respectively.  After
+# that is a text string for the match, and a pattern string.  Strings can be
+# quoted (if desired) in either double or single quotes, as well as backticks.
+#
+# MATCH FNMATCH_SAME "text to match" 'pattern to use'
+
+# Basic wildmat features
+1 1 foo			foo
+0 1 foo			bar
+1 1 ''			""
+1 1 foo			???
+0 1 foo			??
+1 1 foo			*
+1 1 foo			f*
+0 1 foo			*f
+1 1 foo			*foo*
+1 1 foobar		*ob*a*r*
+1 1 aaaaaaabababab	*ab
+1 1 foo*		foo\*
+0 1 foobar		foo\*bar
+1 1 f\oo		f\\oo
+1 1 ball		*[al]?
+0 1 ten			[ten]
+1 1 ten			**[!te]
+0 1 ten			**[!ten]
+1 1 ten			t[a-g]n
+0 1 ten			t[!a-g]n
+1 1 ton			t[!a-g]n
+1 1 ton			t[^a-g]n
+1 1 a]b			a[]]b
+1 1 a-b			a[]-]b
+1 1 a]b			a[]-]b
+0 1 aab			a[]-]b
+1 1 aab			a[]a-]b
+1 1 ]			]
+
+# Extended slash-matching features
+0 1 foo/baz/bar		foo*bar
+1 1 foo/baz/bar		foo**bar
+0 1 foo/bar		foo?bar
+0 1 foo/bar		foo[/]bar
+0 1 foo/bar		f[^eiu][^eiu][^eiu][^eiu][^eiu]r
+1 1 foo-bar		f[^eiu][^eiu][^eiu][^eiu][^eiu]r
+0 1 foo			**/foo
+1 1 /foo		**/foo
+1 1 bar/baz/foo		**/foo
+0 1 bar/baz/foo		*/foo
+0 0 foo/bar/baz		**/bar*
+1 1 deep/foo/bar/baz	**/bar/*
+#0 1 deep/foo/bar/baz/	**/bar/*
+1 1 deep/foo/bar/baz/	**/bar/**
+0 1 deep/foo/bar	**/bar/*
+1 1 deep/foo/bar/	**/bar/**
+1 1 foo/bar/baz		**/bar**
+1 1 foo/bar/baz/x	*/bar/**
+0 0 deep/foo/bar/baz/x	*/bar/**
+1 1 deep/foo/bar/baz/x	**/bar/*/*
+
+# Various additional tests
+0 1 acrt		a[c-c]st
+1 1 acrt		a[c-c]rt
+0 1 ]			[!]-]
+1 1 a			[!]-]
+0 1 ''			\
+#0 1 \			\
+#0 1 /\			*/\
+1 1 /\			*/\\
+1 1 foo			foo
+1 1 @foo		@foo
+0 1 foo			@foo
+1 1 [ab]		\[ab]
+1 1 [ab]		[[]ab]
+#1 1 [ab]		[[:]ab]
+0 1 [ab]		[[::]ab]
+#1 1 [ab]		[[:digit]ab]
+1 1 [ab]		[\[:]ab]
+1 1 ?a?b		\??\?b
+1 1 abc			\a\b\c
+0 1 foo			''
+1 1 foo/bar/baz/to	**/t[o]
+
+# Character class tests
+1 1 a1B		[[:alpha:]][[:digit:]][[:upper:]]
+0 1 a		[[:digit:][:upper:][:space:]]
+1 1 A		[[:digit:][:upper:][:space:]]
+1 1 1		[[:digit:][:upper:][:space:]]
+#0 1 1		[[:digit:][:upper:][:spaci:]]
+1 1 ' '		[[:digit:][:upper:][:space:]]
+0 1 .		[[:digit:][:upper:][:space:]]
+1 1 .		[[:digit:][:punct:][:space:]]
+1 1 5		[[:xdigit:]]
+1 1 f		[[:xdigit:]]
+1 1 D		[[:xdigit:]]
+1 1 _		[[:alnum:][:alpha:][:blank:][:cntrl:][:digit:][:graph:][:lower:][:print:][:punct:][:space:][:upper:][:xdigit:]]
+#1 1 …		[^[:alnum:][:alpha:][:blank:][:cntrl:][:digit:][:graph:][:lower:][:print:][:punct:][:space:][:upper:][:xdigit:]]
+1 1 		[^[:alnum:][:alpha:][:blank:][:digit:][:graph:][:lower:][:print:][:punct:][:space:][:upper:][:xdigit:]]
+1 1 .		[^[:alnum:][:alpha:][:blank:][:cntrl:][:digit:][:lower:][:space:][:upper:][:xdigit:]]
+1 1 5		[a-c[:digit:]x-z]
+1 1 b		[a-c[:digit:]x-z]
+#1 1 y		[a-c[:digit:]x-z]
+0 1 q		[a-c[:digit:]x-z]
+
+# Additional tests, including some malformed wildmats
+1 1 ]		[\\-^]
+0 1 [		[\\-^]
+1 1 -		[\-_]
+1 1 ]		[\]]
+0 1 \]		[\]]
+0 1 \		[\]]
+0 1 ab		a[]b
+0 1 a[]b	a[]b
+0 1 ab[		ab[
+0 1 ab		[!
+0 1 ab		[-
+1 1 -		[-]
+0 1 -		[a-
+0 1 -		[!a-
+1 1 -		[--A]
+1 1 5		[--A]
+1 1 ' '		'[ --]'
+1 1 $		'[ --]'
+1 1 -		'[ --]'
+0 1 0		'[ --]'
+1 1 -		[---]
+1 1 -		[------]
+0 1 j		[a-e-n]
+1 1 -		[a-e-n]
+1 1 a		[!------]
+0 1 [		[]-a]
+1 1 ^		[]-a]
+0 1 ^		[!]-a]
+1 1 [		[!]-a]
+1 1 ^		[a^bc]
+1 1 -b]		[a-]b]
+0 1 \		[\]
+1 1 \		[\\]
+0 1 \		[!\\]
+1 1 G		[A-\\]
+0 1 aaabbb	b*a
+0 1 aabcaa	*ba*
+1 1 ,		[,]
+1 1 ,		[\\,]
+1 1 \		[\\,]
+1 1 -		[,-.]
+0 1 +		[,-.]
+0 1 -.]		[,-.]
+1 1 2		[\1-\3]
+1 1 3		[\1-\3]
+0 1 4		[\1-\3]
+1 1 \		[[-\]]
+1 1 [		[[-\]]
+1 1 ]		[[-\]]
+0 1 -		[[-\]]
+
+# Test recursion and the abort code (use "wildtest -i" to see iteration counts)
+1 1 -adobe-courier-bold-o-normal--12-120-75-75-m-70-iso8859-1	-*-*-*-*-*-*-12-*-*-*-m-*-*-*
+0 1 -adobe-courier-bold-o-normal--12-120-75-75-X-70-iso8859-1	-*-*-*-*-*-*-12-*-*-*-m-*-*-*
+0 1 -adobe-courier-bold-o-normal--12-120-75-75-/-70-iso8859-1	-*-*-*-*-*-*-12-*-*-*-m-*-*-*
+1 1 /adobe/courier/bold/o/normal//12/120/75/75/m/70/iso8859/1	/*/*/*/*/*/*/12/*/*/*/m/*/*/*
+0 1 /adobe/courier/bold/o/normal//12/120/75/75/X/70/iso8859/1	/*/*/*/*/*/*/12/*/*/*/m/*/*/*
+1 1 abcd/abcdefg/abcdefghijk/abcdefghijklmnop.txt		**/*a*b*g*n*t
+0 1 abcd/abcdefg/abcdefghijk/abcdefghijklmnop.txtz		**/*a*b*g*n*t

--- a/configure.ac
+++ b/configure.ac
@@ -201,6 +201,16 @@ else
 fi
 AC_DEFINE_UNQUOTED(RSYNC_RSH, "$RSYNC_RSH", [default -e command])
 
+AC_ARG_WITH(check,
+	AS_HELP_STRING([--with-check],[enable unit tests with libcheck (default: no)]))
+
+if test x"$with_check" != x; then
+	RSYNC_CHECK_UNIT="check_unit"
+else
+	RSYNC_CHECK_UNIT=""
+fi
+AC_SUBST(RSYNC_CHECK_UNIT)
+
 # Some programs on solaris are only found in /usr/xpg4/bin (or work better than others versions).
 AC_PATH_PROG(SHELL_PATH, sh, /bin/sh, [/usr/xpg4/bin$PATH_SEPARATOR$PATH])
 AC_PATH_PROG(FAKEROOT_PATH, fakeroot, /usr/bin/fakeroot, [/usr/xpg4/bin$PATH_SEPARATOR$PATH])

--- a/wildtest.c
+++ b/wildtest.c
@@ -160,6 +160,7 @@ parse_line(char ** argv, int line, char * buf, int * flag, char ** end, char ** 
     return 1;
 }
 
+#ifndef RSYNC_WILDTEST_NO_MAIN
 int
 main(int argc, char **argv)
 {
@@ -235,3 +236,4 @@ main(int argc, char **argv)
 
     return 0;
 }
+#endif /* RSYNC_WILDTEST_NO_MAIN */


### PR DESCRIPTION
Quite a large PR, with some opinions baked into it.

1. add optional detection and use of lib check for unit testing

2. minor modifications to source files to make it easier to get them under unit tests (eg # ifndef wrappers)

3.  Quite a lot of unit test code that is aiming for full *coverage* without being a clear documentation of *behavior*. 

My goal here is to start getting unit tests in place that hold the behavior fixed, which will make it easier to refactor code without changing behavior, and also, replace the unit test code that is working hard to cover some branch with a more idiomatic test that helps explain *why* that branch is there and what makes it hard to cover. 