### PR TITLE
systemd: restart daemon on-failure

### DIFF
--- a/packaging/systemd/rsync.service
+++ b/packaging/systemd/rsync.service
@@ -7,6 +7,7 @@ Documentation=man:rsync(1) man:rsyncd.conf(5)
 [Service]
 ExecStart=/usr/bin/rsync --daemon --no-detach
 RestartSec=1
+Restart=on-failure
 
 # Citing README.md:
 #


### PR DESCRIPTION
man 5 systemd.service:
> Setting this to on-failure is the recommended choice for long-running services

Partial fix for https://bugzilla.samba.org/show_bug.cgi?id=13463