### PR TITLE
Avoid malfunctions and unexpected errors with git-set-file-times

### DIFF
--- a/support/git-set-file-times
+++ b/support/git-set-file-times
@@ -38,7 +38,7 @@ def main():
                 print_line(fn, mtime, mtime)
             ls.discard(fn)
 
-    cmd = git + 'log -r --name-only --no-color --pretty=raw --no-renames -z'.split()
+    cmd = git + 'log -r --name-only --format=%x00commit%x20%H%n%x00commit_time%x20%ct%n --no-renames -z'.split()
     if args.tree:
         cmd.append(args.tree)
     cmd += ['--'] + args.files
@@ -46,7 +46,7 @@ def main():
     proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, encoding='utf-8')
     for line in proc.stdout:
         line = line.strip()
-        m = re.match(r'^committer .*? (\d+) [-+]\d+$', line)
+        m = re.match(r'^\0commit_time (\d+)$', line)
         if m:
             commit_time = int(m[1])
         elif NULL_COMMIT_RE.search(line):


### PR DESCRIPTION
Solve the following problems with support/git-set-file-times:
* mishandling of commit message lines similar to committer lines
* UnicodeDecodeError with commit messages that cannot be interpreted
  as utf-8

# How to reproduce problems

```
$ mkdir repo
$ cd repo
$ git init
$ touch README
$ git add README
$ git commit -m "committer foo 0 +0000"
$ ls -l README
-rw-rw-r-- 1 vagrant vagrant 0 Apr  3 11:39 README
$ git set-file-times
Setting README
$ ls -l README
-rw-rw-r-- 1 vagrant vagrant 0 Jan  1  1970 README
```

```
$ git clone https://github.com/git/git
$ cd git
$ git set-file-times
...
Setting t/t3900/ISO-2022-JP.txt
Setting t/t3900/1-UTF-8.txt
Setting t/t3900/2-UTF-8.txt
Setting compat/strlcpy.c
Traceback (most recent call last):
  File "/vagrant/git-set-file-times", line 92, in <module>
    main()
  File "/vagrant/git-set-file-times", line 47, in main
    for line in proc.stdout:
  File "/usr/lib/python3.8/codecs.py", line 322, in decode
    (result, consumed) = self._buffer_decode(data, self.errors, final)
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xf8 in position 404: invalid start byte
```