### PR TITLE
fix static build with external zlib

### DIFF
--- a/clientname.c
+++ b/clientname.c
@@ -189,12 +189,12 @@ int read_proxy_protocol_header(int fd)
 		} v2;
 	} hdr;
 
-	read_buf(fd, (char*)&hdr, PROXY_V2_SIG_SIZE);
+	rsync_read_buf(fd, (char*)&hdr, PROXY_V2_SIG_SIZE);
 
 	if (memcmp(hdr.v2.sig, proxyv2sig, PROXY_V2_SIG_SIZE) == 0) { /* Proxy V2 */
 		int ver, cmd, size;
 
-		read_buf(fd, (char*)&hdr + PROXY_V2_SIG_SIZE, PROXY_V2_HEADER_SIZE - PROXY_V2_SIG_SIZE);
+		rsync_read_buf(fd, (char*)&hdr + PROXY_V2_SIG_SIZE, PROXY_V2_HEADER_SIZE - PROXY_V2_SIG_SIZE);
 
 		ver = (hdr.v2.ver_cmd & 0xf0) >> 4;
 		cmd = (hdr.v2.ver_cmd & 0x0f);
@@ -204,7 +204,7 @@ int read_proxy_protocol_header(int fd)
 			return 0;
 
 		/* Grab all the remaining data in the binary request. */
-		read_buf(fd, (char*)&hdr + PROXY_V2_HEADER_SIZE, size);
+		rsync_read_buf(fd, (char*)&hdr + PROXY_V2_HEADER_SIZE, size);
 
 		switch (cmd) {
 		case CMD_PROXY:
@@ -243,7 +243,7 @@ int read_proxy_protocol_header(int fd)
 		*p = '\0';
 		if (!strchr(hdr.v1.line, '\n')) {
 			while (1) {
-				read_buf(fd, p, 1);
+				rsync_read_buf(fd, p, 1);
 				if (*p++ == '\n')
 					break;
 				if (p - hdr.v1.line >= (int)sizeof hdr.v1.line - 1)

--- a/clientserver.c
+++ b/clientserver.c
@@ -1344,7 +1344,7 @@ int start_daemon(int f_in, int f_out)
 			return -1;
 		}
 		early_input = new_array(char, early_input_len);
-		read_buf(f_in, early_input, early_input_len);
+		rsync_read_buf(f_in, early_input, early_input_len);
 
 		if (!read_line_old(f_in, line, sizeof line, 0))
 			return -1;

--- a/flist.c
+++ b/flist.c
@@ -1184,7 +1184,7 @@ static struct file_struct *recv_file_entry(int f, struct file_list *flist, int x
 			struct file_struct *first = flist->files[first_hlink_ndx - flist->ndx_start];
 			memcpy(bp, F_SUM(first), flist_csum_len);
 		} else
-			read_buf(f, bp, flist_csum_len);
+			rsync_read_buf(f, bp, flist_csum_len);
 	}
 
 #ifdef SUPPORT_ACLS

--- a/receiver.c
+++ b/receiver.c
@@ -403,7 +403,7 @@ static int receive_data(int f_in, char *fname_r, int fd_r, OFF_T size_r,
 	if (mapbuf)
 		unmap_file(mapbuf);
 
-	read_buf(f_in, sender_file_sum, sum_len);
+	rsync_read_buf(f_in, sender_file_sum, sum_len);
 	if (DEBUG_GTE(DELTASUM, 2))
 		rprintf(FINFO,"got file_sum\n");
 	if (fd != -1 && memcmp(file_sum1, sender_file_sum, sum_len) != 0)

--- a/sender.c
+++ b/sender.c
@@ -95,7 +95,7 @@ static struct sum_struct *receive_sums(int f)
 
 	for (i = 0; i < s->count; i++) {
 		s->sums[i].sum1 = read_int(f);
-		read_buf(f, s->sums[i].sum2, s->s2length);
+		rsync_read_buf(f, s->sums[i].sum2, s->s2length);
 
 		s->sums[i].offset = offset;
 		s->sums[i].flags = 0;

--- a/token.c
+++ b/token.c
@@ -297,7 +297,7 @@ static int32 simple_recv_token(int f, char **data)
 	*data = buf;
 	n = MIN(CHUNK_SIZE,residue);
 	residue -= n;
-	read_buf(f,buf,n);
+	rsync_read_buf(f,buf,n);
 	return n;
 }
 
@@ -534,7 +534,7 @@ static int32 recv_deflated_token(int f, char **data)
 				flag = read_byte(f);
 			if ((flag & 0xC0) == DEFLATED_DATA) {
 				n = ((flag & 0x3f) << 8) + read_byte(f);
-				read_buf(f, cbuf, n);
+				rsync_read_buf(f, cbuf, n);
 				rx_strm.next_in = (Bytef *)cbuf;
 				rx_strm.avail_in = n;
 				recv_state = r_inflating;
@@ -813,7 +813,7 @@ static int32 recv_zstd_token(int f, char **data)
 			flag = read_byte(f);
 			if ((flag & 0xC0) == DEFLATED_DATA) {
 				n = ((flag & 0x3f) << 8) + read_byte(f);
-				read_buf(f, cbuf, n);
+				rsync_read_buf(f, cbuf, n);
 
 				zstd_in_buff.size = n;
 				zstd_in_buff.pos = 0;
@@ -978,7 +978,7 @@ static int32 recv_compressed_token(int f, char **data)
 			flag = read_byte(f);
 			if ((flag & 0xC0) == DEFLATED_DATA) {
 				n = ((flag & 0x3f) << 8) + read_byte(f);
-				read_buf(f, cbuf, n);
+				rsync_read_buf(f, cbuf, n);
 				next_in = (char *)cbuf;
 				avail_in = n;
 				recv_state = r_inflating;

--- a/xattrs.c
+++ b/xattrs.c
@@ -755,7 +755,7 @@ int recv_xattr_request(struct file_struct *file, int f_in)
 		memcpy(name, rxa->name, rxa->name_len);
 		rxa->name = name;
 		free(old_datum);
-		read_buf(f_in, rxa->datum, rxa->datum_len);
+		rsync_read_buf(f_in, rxa->datum, rxa->datum_len);
 		got_xattr_data = 1;
 	}
 
@@ -803,16 +803,16 @@ void receive_xattr(int f, struct file_struct *file)
 			overflow_exit("receive_xattr");
 		ptr = new_array(char, dget_len + extra_len + name_len);
 		name = ptr + dget_len + extra_len;
-		read_buf(f, name, name_len);
+		rsync_read_buf(f, name, name_len);
 		if (name_len < 1 || name[name_len-1] != '\0') {
 			rprintf(FERROR, "Invalid xattr name received (missing trailing \\0).\n");
 			exit_cleanup(RERR_FILEIO);
 		}
 		if (dget_len == datum_len)
-			read_buf(f, ptr, dget_len);
+			rsync_read_buf(f, ptr, dget_len);
 		else {
 			*ptr = XSTATE_ABBREV;
-			read_buf(f, ptr + 1, MAX_DIGEST_LEN);
+			rsync_read_buf(f, ptr + 1, MAX_DIGEST_LEN);
 		}
 
 		if (saw_xattr_filter) {


### PR DESCRIPTION
Fix the following static build failure when using an external zlib:
```
/home/autobuild/autobuild/instance-11/output-1/host/bin/i686-buildroot-linux-uclibc-gcc -D_LARGEFILE_SOURCE -D_LARGEFILE64_SOURCE -D_FILE_OFFSET_BITS=64  -Og -g0  -static -DHAVE_CONFIG_H -Wall -W -Wno-unused-parameter -static -o rsync flist.o rsync.o generator.o receiver.o cleanup.o sender.o exclude.o util.o util2.o main.o checksum.o match.o syscall.o log.o backup.o delete.o options.o io.o compat.o hlink.o token.o uidlist.o socket.o hashtable.o usage.o fileio.o batch.o clientname.o chmod.o acls.o xattrs.o progress.o pipe.o   params.o loadparm.o clientserver.o access.o connection.o authenticate.o lib/wildmatch.o lib/compat.o lib/snprintf.o lib/mdfour.o lib/md5.o lib/permstring.o lib/pool_alloc.o lib/sysacls.o lib/sysxattrs.o    -lz -lpopt -liconv
/home/autobuild/autobuild/instance-11/output-1/host/lib/gcc/i686-buildroot-linux-uclibc/9.4.0/../../../../i686-buildroot-linux-uclibc/bin/ld: /home/autobuild/autobuild/instance-11/output-1/host/i686-buildroot-linux-uclibc/sysroot/usr/lib/libz.a(deflate.c.o): in function `read_buf':
deflate.c:(.text+0xb93): multiple definition of `read_buf'; io.o:io.c:(.text+0x2bf4): first defined here
```

This build failure is raised because the external zlib doesn't is not patched by https://github.com/WayneD/rsync/commit/12febd804fcfbcbef7325610699aaae4597635c1

Fixes:
 - http://autobuild.buildroot.org/results/488453197da880dda8f47b71ff302192bcbb6679

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>