### PR TITLE
Use SOURCE_DATE_EPOCH on manpage generation (reproducible build)

### DIFF
--- a/md-convert
+++ b/md-convert
@@ -241,7 +241,7 @@ def find_man_substitutions():
                 if var == 'srcdir':
                     break
 
-    env_subs['date'] = time.strftime('%d %b %Y', time.localtime(mtime))
+    env_subs['date'] = time.strftime('%d %b %Y', time.gmtime(int(os.environ.get('SOURCE_DATE_EPOCH', time.time()))))
 
 
 def html_via_commonmark(txt):


### PR DESCRIPTION
Whilst working on the Reproducible Builds effort [0] we noticed that
rsync could not be built reproducibly.

This was because the manpage generation used the current date for the
manual page header.

A patch is attached that will use SOURCE_DATE_EPOCH if available.

[0] https://reproducible-builds.org/