### PR TITLE
Use gmtime instead of localtime on manpage generation (reproducible build)

### DIFF
--- a/md-convert
+++ b/md-convert
@@ -241,7 +241,7 @@ def find_man_substitutions():
                 if var == 'srcdir':
                     break
 
-    env_subs['date'] = time.strftime('%d %b %Y', time.localtime(mtime))
+    env_subs['date'] = time.strftime('%d %b %Y', time.gmtime(mtime)
 
 
 def html_via_commonmark(txt):


### PR DESCRIPTION
Whilst working on the Reproducible Builds effort [0] we noticed that
rsync could not be built reproducibly.

This was because the manpage generation used localtime for the
manual page header (affected by TZ).

A patch is attached that will use gmtime instead.

[0] https://reproducible-builds.org/

This is a follow-up PR on https://github.com/WayneD/rsync/pull/311
I could not update/reopen the original PR after force-pushing to my fork, Github lost track of it so I ended up having to create a new one.