### PR TITLE
Define the 'really old versions' for '--old-args' for clarity

### DIFF
--- a/rsync.1.md
+++ b/rsync.1.md
@@ -182,7 +182,7 @@ spaces from the local shell but not also from the remote shell:
 
 >     rsync -aiv host:'a simple file.pdf' /dest/
 
-Really old versions of rsync only allowed specifying one remote-source arg, so
+Pre 3.2.4 versions of rsync only allowed specifying one remote-source arg, so
 it required the remote side to split the args at a space.  You can still get
 this old-style arg splitting by using the [`--old-args`](#opt) option:
 


### PR DESCRIPTION
It's not clear what 'Really old versions' is supposed to mean. With the `--old-args` being the default in 3.2.3, users may be scratching their heads why 'really old versions' refers to a version only one minor release behind.

This PR is supposed to related to the loss of backwards compatibility for parameter parsing as detailed in #318.