### PR TITLE
configure.ac: use pkg-config to retrieve openssl dependencies

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -432,11 +432,15 @@ AH_TEMPLATE([USE_OPENSSL],
 if test x"$enable_openssl" != x"no"; then
     if test x"$ac_cv_header_openssl_md4_h" = x"yes" && test x"$ac_cv_header_openssl_md5_h" = x"yes"; then
       AC_MSG_RESULT(yes)
-      AC_SEARCH_LIBS(EVP_MD_CTX_copy, crypto,
+      PKG_CHECK_MODULES(LIBCRYPTO, libcrypto,
           [AC_DEFINE(USE_OPENSSL)
-	   enable_openssl=yes],
-          [err_msg="$err_msg$nl- Failed to find EVP_MD_CTX_copy function in openssl crypto lib.";
-	   no_lib="$no_lib openssl"])
+           enable_openssl=yes
+           LIBS="$LIBS $LIBCRYPTO_LIBS"],
+          [AC_SEARCH_LIBS(EVP_MD_CTX_copy, crypto,
+              [AC_DEFINE(USE_OPENSSL)
+	       enable_openssl=yes],
+              [err_msg="$err_msg$nl- Failed to find EVP_MD_CTX_copy function in openssl crypto lib.";
+	       no_lib="$no_lib openssl"])])
     else
         AC_MSG_RESULT(no)
 	err_msg="$err_msg$nl- Failed to find openssl/md4.h and openssl/md5.h for openssl crypto lib support."


### PR DESCRIPTION
Use pkg-config to retrieve openssl dependencies such as `-latomic` and avoids the following build failure when building statically on architectures such as sparc:

```
/home/autobuild/autobuild/instance-1/output-1/host/lib/gcc/sparc-buildroot-linux-uclibc/10.4.0/../../../../sparc-buildroot-linux-uclibc/bin/ld: /home/autobuild/autobuild/instance-1/output-1/host/sparc-buildroot-linux-uclibc/sysroot/usr/lib/libcrypto.a(threads_pthread.o): in function `CRYPTO_atomic_add': threads_pthread.c:(.text+0x208): undefined reference to `__atomic_is_lock_free'
```

Fixes:
 - http://autobuild.buildroot.org/results/49abbaa1eab94b248bff434b40728065d687e278

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>