### PR TITLE
Add option --log-after to log after moving file into place

### DIFF
--- a/main.c
+++ b/main.c
@@ -93,7 +93,10 @@ extern int trust_sender_filter;
 extern int trust_sender_args;
 extern struct stats stats;
 extern char *stdout_format;
+extern char *logfile_name;
 extern char *logfile_format;
+extern char *logafter_name;
+extern int log_after_transfer;
 extern char *filesfrom_host;
 extern char *partial_dir;
 extern char *rsync_path;
@@ -1052,6 +1055,10 @@ static int do_recv(int f_in, int f_out, char *local_name)
 		if (read_batch)
 			io_start_buffering_in(f_in);
 		io_start_multiplex_out(f_out);
+
+		/* Reopen log file for --log-after */
+		if (log_after_transfer)
+			logfile_name = logafter_name;
 
 		recv_files(f_in, f_out, local_name);
 		io_flush(FULL_FLUSH);

--- a/options.c
+++ b/options.c
@@ -176,7 +176,9 @@ char *basis_dir[MAX_BASIS_DIRS+1];
 char *config_file = NULL;
 char *shell_cmd = NULL;
 char *logfile_name = NULL;
+char *logafter_name = NULL;
 char *logfile_format = NULL;
+char *logafter_format = NULL;
 char *stdout_format = NULL;
 char *password_file = NULL;
 char *early_input_file = NULL;
@@ -205,6 +207,7 @@ static const char *empty_argv[1];
 int quiet = 0;
 int output_motd = 1;
 int log_before_transfer = 0;
+int log_after_transfer = 0;
 int stdout_format_has_i = 0;
 int stdout_format_has_o_or_i = 0;
 int logfile_format_has_i = 0;
@@ -769,6 +772,7 @@ static struct poptOption long_options[] = {
   {"no-m",             0,  POPT_ARG_VAL,    &prune_empty_dirs, 0, 0, 0 },
   {"log-file",         0,  POPT_ARG_STRING, &logfile_name, 0, 0, 0 },
   {"log-file-format",  0,  POPT_ARG_STRING, &logfile_format, 0, 0, 0 },
+  {"log-after",        0,  POPT_ARG_VAL,    &log_after_transfer, 1, 0, 0 },
   {"out-format",       0,  POPT_ARG_STRING, &stdout_format, 0, 0, 0 },
   {"log-format",       0,  POPT_ARG_STRING, &stdout_format, 0, 0, 0 }, /* DEPRECATED */
   {"itemize-changes", 'i', POPT_ARG_NONE,   0, 'i', 0, 0 },
@@ -2357,7 +2361,10 @@ int parse_arguments(int *argc_p, const char ***argv_p)
 
 	if (logfile_name && !am_daemon) {
 		if (!logfile_format) {
-			logfile_format = "%i %n%L";
+			if (log_after_transfer)
+				logfile_format = "%o %i %n%L";
+			else
+				logfile_format = "%i %n%L";
 			logfile_format_has_i = logfile_format_has_o_or_i = 1;
 		} else {
 			if (log_format_has(logfile_format, 'i'))
@@ -2368,6 +2375,17 @@ int parse_arguments(int *argc_p, const char ***argv_p)
 		log_init(0);
 	} else if (!am_daemon)
 		logfile_format = NULL;
+
+	if (log_after_transfer) {
+		if (!logfile_name || *logfile_name != '/') {
+			snprintf(err_buf, sizeof err_buf,
+				 "--log-after requires --log-file=<absolute path>\n");
+			goto cleanup;
+		}
+		log_before_transfer = 0;
+		logafter_name = logfile_name;
+		logafter_format = logfile_format;
+	}
 
 	if (daemon_bwlimit && (!bwlimit || bwlimit > daemon_bwlimit))
 		bwlimit = daemon_bwlimit;

--- a/receiver.c
+++ b/receiver.c
@@ -28,6 +28,7 @@ extern int am_root;
 extern int am_server;
 extern int inc_recurse;
 extern int log_before_transfer;
+extern int log_after_transfer;
 extern int stdout_format_has_i;
 extern int logfile_format_has_i;
 extern int want_xattr_optim;
@@ -876,7 +877,9 @@ int recv_files(int f_in, int f_out, char *local_name)
 		/* recv file data */
 		recv_ok = receive_data(f_in, fnamecmp, fd1, st.st_size, fname, fd2, file, inplace || one_inplace);
 
-		log_item(log_code, file, iflags, NULL);
+		/* log the transfer result after file is moved into place */
+		if (!log_after_transfer)
+			log_item(log_code, file, iflags, NULL);
 		if (want_progress_now)
 			instant_progress(fname);
 
@@ -916,6 +919,10 @@ int recv_files(int f_in, int f_out, char *local_name)
 				partialptr = NULL;
 		} else if (!one_inplace)
 			do_unlink(fnametmp);
+
+		/* log the transfer result */
+		if (log_after_transfer)
+			log_item(FLOG_AFTER, file, iflags, NULL);
 
 		cleanup_disable();
 

--- a/rsync.1.md
+++ b/rsync.1.md
@@ -543,6 +543,7 @@ has its own detailed description later in this manpage.
 --out-format=FORMAT      output updates using the specified FORMAT
 --log-file=FILE          log what we're doing to the specified FILE
 --log-file-format=FMT    log updates using the specified FMT
+--log-after              log updates after moving file into place
 --password-file=FILE     read daemon-access password from FILE
 --early-input=FILE       use FILE for daemon's early exec input
 --list-only              list the files instead of copying them

--- a/rsync.h
+++ b/rsync.h
@@ -253,8 +253,9 @@ enum logcode {
     FERROR_XFER=1, FINFO=2, /* sent over socket for any protocol */
     FERROR=3, FWARNING=4, /* sent over socket for protocols >= 30 */
     FERROR_SOCKET=5, FLOG=6, /* only sent via receiver -> generator pipe */
+    FCLIENT=7,     /* never transmitted (e.g. server converts to FINFO) */
     FERROR_UTF8=8, /* only sent via receiver -> generator pipe */
-    FCLIENT=7 /* never transmitted (e.g. server converts to FINFO) */
+    FLOG_AFTER=9,  /* receiver logs directly to log file */
 };
 
 /* Messages types that are sent over the message channel.  The logcode


### PR DESCRIPTION
This mode is useful when a process is monitoring the log for post-processing of transferred files.

With --log-after in local mode, both sender and receiver log to the same log file, so it require --log-file with absolute path.

We add %o to the default log format, so it will be easy to tell the logs of the sender from the logs of the receiver:

2023/02/14 14:40:25 [559755] building file list
2023/02/14 14:40:25 [559755] send >f+++++++++ foo
2023/02/14 14:40:25 [559757] recv >f+++++++++ foo
2023/02/14 14:40:25 [559755] sent 111 bytes  received 35 bytes  292.00 bytes/sec 2023/02/14 14:40:25 [559755] total size is 4  speedup is 0.03