### PR TITLE
Allow --files-from to be used without a destination

### DIFF
--- a/options.c
+++ b/options.c
@@ -2445,7 +2445,7 @@ int parse_arguments(int *argc_p, const char ***argv_p)
 	if (files_from) {
 		char *h, *p;
 		int q;
-		if (argc > 2 || (!am_daemon && !am_server && argc == 1)) {
+		if (argc > 2) {
 			usage(FERROR);
 			exit_cleanup(RERR_SYNTAX);
 		}


### PR DESCRIPTION
A syntax check currently prevents the option `--files-from=list_of_files.txt` to be used together without a destination (implied `--list-only`).

    $ rsync --files-from=dirs_to_backup.txt --recursive ./
    [...]
    rsync error: syntax or usage error (code 1) at options.c(2433) [client=3.2.7]

This makes it hard to list all local files from rsync's perspective, that is, after processing of `--include`, `--exclude`, `--recursive`, and IO/permission errors during listing.  Note that this list should be independent of destination.

In my case, `dirs_to_backup.txt` points to directories such as `~/camera/` and `~/.conf/`, and I'd like to keep a list of all "files to back up", for validation and troubleshooting purposes. This should be possible even when the remote host is offline. My current workaround is to dry-run a transfer to a temp dir:

    $ rsync --files-from=dirs_to_backup.txt [... other flags ...] --dry-run --itemize-changes ./ "$(mktemp -d)"

But this is obviously not ideal, from a clarity and performance perspective.

I think the check that throws a syntax error when `!am_daemon && !am_server && argc == 1` was either added incorrectly, or before the introduction of `--list-only`. This pull request removes this check, allowing the example above to work.
