### PR TITLE
Using a correct time in log file

### DIFF
--- a/clientserver.c
+++ b/clientserver.c
@@ -976,6 +976,8 @@ static int rsync_module(int f_in, int f_out, int i, const char *addr, const char
 	}
 
 	if (use_chroot) {
+		/* Cache timezone data before chroot makes /etc/localtime inaccessible */
+		tzset();
 		if (chroot(module_chdir)) {
 			rsyserr(FLOG, errno, "chroot(\"%s\") failed", module_chdir);
 			io_printf(f_out, "@ERROR: chroot failed\n");
@@ -1301,6 +1303,7 @@ int start_daemon(int f_in, int f_out)
 	p = lp_daemon_chroot();
 	if (*p) {
 		log_init(0); /* Make use we've initialized syslog before chrooting. */
+		tzset();
 		if (chroot(p) < 0) {
 			rsyserr(FLOG, errno, "daemon chroot(\"%s\") failed", p);
 			return -1;

--- a/options.c
+++ b/options.c
@@ -1159,7 +1159,7 @@ static time_t parse_time(const char *arg)
 {
 	const char *cp;
 	time_t val, now = time(NULL);
-	struct tm t, *today = localtime(&now);
+	struct tm t, tmp, *today = localtime_r(&now, &tmp);
 	int in_date, old_mday, n;
 
 	memset(&t, 0, sizeof t);

--- a/tls.c
+++ b/tls.c
@@ -127,7 +127,7 @@ static void storetime(char *dest, size_t destsize, time_t t, int nsecs)
 {
 	if (t) {
 		int len;
-		struct tm *mt = gmtime(&t);
+		struct tm tmp, *mt = gmtime_r(&t, &tmp);
 
 		len = snprintf(dest, destsize,
 			" %04d-%02d-%02d %02d:%02d:%02d",

--- a/util1.c
+++ b/util1.c
@@ -1393,7 +1393,7 @@ char *timestring(time_t t)
 	static int ndx = 0;
 	static char buffers[4][20]; /* We support 4 simultaneous timestring results. */
 	char *TimeBuf = buffers[ndx = (ndx + 1) % 4];
-	struct tm *tm = localtime(&t);
+	struct tm tmp, *tm = localtime_r(&t, &tmp);
 	int len = snprintf(TimeBuf, sizeof buffers[0], "%4d/%02d/%02d %02d:%02d:%02d",
 		 (int)tm->tm_year + 1900, (int)tm->tm_mon + 1, (int)tm->tm_mday,
 		 (int)tm->tm_hour, (int)tm->tm_min, (int)tm->tm_sec);


### PR DESCRIPTION
This should fix https://github.com/RsyncProject/rsync/issues/729. Log after the fix:
```
2025/01/31 08:40:27 [2500] rsyncd version 3.4.1 starting, listening on port 873
2025/01/31 08:40:33 [2501] name lookup failed for 10.X.X.X: Name or service not known
2025/01/31 08:40:33 [2501] connect from UNKNOWN (10.X.X.X)
2025/01/31 08:40:33 [2501] rsync allowed access on module test from UNKNOWN (10.X.X.X)
2025/01/31 08:40:34 [2501] rsync on test/ from UNKNOWN (10.X.X.X)
2025/01/31 08:40:34 [2501] building file list
2025/01/31 08:40:35 [2501] send UNKNOWN [10.X.X.X] test () finch-2.14.10-2.fc35.x86_64.rpm 143985
2025/01/31 08:40:36 [2501] send UNKNOWN [10.X.X.X] test () finch-debuginfo-2.14.10-2.fc35.x86_64.rpm 348677
2025/01/31 08:40:37 [2501] send UNKNOWN [10.X.X.X] test () finch-devel-2.14.10-2.fc35.x86_64.rpm 17181
2025/01/31 08:40:37 [2501] send UNKNOWN [10.X.X.X] test () libpcap-1.10.0-4.fc38.x86_64.rpm 178919
2025/01/31 08:40:39 [2501] send UNKNOWN [10.X.X.X] test () libpcap-debuginfo-1.10.0-4.fc38.x86_64.rpm 375005
```
Credit for the fix goes to https://github.com/remicollet