### PR TITLE
chore: gitignore MacOS debug symbols

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,4 @@ aclocal.m4
 /auto-build-save
 .deps
 /*.exe
+*.dSYM/


### PR DESCRIPTION
## Summary

The current `.gitignore` misses `*.dSYM/` directories when building on MacOS. This PR adds it to the `.gitignore`.