### PR TITLE
Make the build reproducible

### DIFF
--- a/md-convert
+++ b/md-convert
@@ -248,6 +248,9 @@ def find_man_substitutions():
 
     env_subs['date'] = time.strftime('%d %b %Y', time.gmtime(mtime + tz_offset)).lstrip('0')
 
+    if 'SOURCE_DATE_EPOCH' in os.environ:
+        env_subs['date'] = time.strftime('%d %b %Y', time.gmtime(int(os.environ.get('SOURCE_DATE_EPOCH', time.time()))))
+
 
 def html_via_commonmark(txt):
     return commonmark.HtmlRenderer().render(commonmark.Parser().parse(txt))


### PR DESCRIPTION
From https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1093201: Whilst working on the Reproducible Builds effort [0], we noticed that rsync could not be built reproducibly.

This is because the date in the manual page can vary depending on whether there is a .git directory and the modification time of version.h and Mafile, which might get modified when patching via quilt.

A patch is attached that makes this use SOURCE_DATE_EPOCH, which will always be reliable.