### PR TITLE
fixed an invalid access to files array

### DIFF
--- a/sender.c
+++ b/sender.c
@@ -262,6 +262,8 @@ void send_files(int f_in, int f_out)
 
 		if (ndx - cur_flist->ndx_start >= 0)
 			file = cur_flist->files[ndx - cur_flist->ndx_start];
+		else if (cur_flist->parent_ndx < 0)
+			exit_cleanup(RERR_PROTOCOL);
 		else
 			file = dir_flist->files[cur_flist->parent_ndx];
 		if (F_PATHNAME(file)) {


### PR DESCRIPTION
this was found by Calum Hutton from Rapid7. It is a real bug, but analysis shows it can't be leverged into an exploit. Worth fixing though.

Many thanks to Calum and Rapid7 for finding and reporting this