### PR TITLE
improve the attribute parsing by reducing to one the memmove for FreeBSD

### DIFF
--- a/lib/sysxattrs.c
+++ b/lib/sysxattrs.c
@@ -142,15 +142,12 @@ ssize_t sys_llistxattr(const char *path, char *list, size_t size)
 	 * terminator.  We need to change this into a series of null-terminted
 	 * strings.  Since the size is the same, we can simply transform the
 	 * output in place. */
-	for (off = 0; off < len; off += keylen + 1) {
-		keylen = ((unsigned char*)list)[off];
-		if (off + keylen >= len) {
-			/* Should be impossible, but bugs happen! */
-			errno = EINVAL;
-			return -1;
-		}
-		memmove(list+off, list+off+1, keylen);
-		list[off+keylen] = '\0';
+	keylen = (unsigned char)list[0];
+	memmove(list, list+1, len-1);
+	list[len-1] = '\0';
+	for (off = keylen; off < (len - 1); off += (keylen + 1)) {
+		keylen = (unsigned char)list[off];
+		list[off] = '\0';
 	}
 
 	return len;


### PR DESCRIPTION
calls when converting FreeBSD attribute list to the format used by Linux and extend the rsync unit tests for long xattrs lists.

This is part of the patches currently applied to rsync on FreeBSD