### PR TITLE
Harden systemd service with safe defaults

### DIFF
--- a/packaging/systemd/rsync.service
+++ b/packaging/systemd/rsync.service
@@ -25,8 +25,30 @@ Restart=on-failure
 
 ProtectSystem=full
 #ProtectHome=on|off|read-only
+
+# These are general hardening parameters that should not affect file access
 PrivateDevices=on
 NoNewPrivileges=on
+MemoryDenyWriteExecute=on
+LockPersonality=on
+ProtectClock=on
+ProtectControlGroups=on
+ProtectHostname=on
+ProtectKernelLogs=on
+ProtectKernelModules=on
+ProtectKernelTunables=on
+ProtectProc=invisible
+ProcSubset=pid
+RestrictNamespaces=on
+RestrictRealtime=on
+SystemCallArchitectures=native
+SystemCallErrorNumber=EPERM
+SystemCallFilter=@system-service
+
+# We only listen on TCP sockets
+SocketBindAllow=ipv4:tcp
+SocketBindAllow=ipv6:tcp
+SocketBindDeny=any
 
 [Install]
 WantedBy=multi-user.target

--- a/packaging/systemd/rsync@.service
+++ b/packaging/systemd/rsync@.service
@@ -24,5 +24,28 @@ StandardError=journal
 
 ProtectSystem=full
 #ProtectHome=on|off|read-only
+
+# These are general hardening parameters that should not affect file access
 PrivateDevices=on
 NoNewPrivileges=on
+MemoryDenyWriteExecute=on
+LockPersonality=on
+ProtectClock=on
+ProtectControlGroups=on
+ProtectHostname=on
+ProtectKernelLogs=on
+ProtectKernelModules=on
+ProtectKernelTunables=on
+ProtectProc=invisible
+ProcSubset=pid
+RestrictNamespaces=on
+RestrictRealtime=on
+SystemCallArchitectures=native
+SystemCallErrorNumber=EPERM
+SystemCallFilter=@system-service
+
+# These settings work only for inetd-style activation
+RestrictAddressFamilies=AF_UNIX
+PrivateNetwork=on
+IPAddressDeny=any
+


### PR DESCRIPTION
See commit message for an overview, but this is an RFC, I can understand if the project does not want this. The goal here is defense in depth. If there is a bug in any access control or authentication mechanism in rsync, there should be additional protections to not compromise a system running `rsync --daemon` as root. This can be accomplished through systemd, so that the damage done by a hypothetical RCE is minimized as much as possible. 

**I have personally tested this and it does not affect file transfers for either unit**. That being said, I understand a lot of the options may be confusing. I can explain why each one of these is a safe default that *does not affect file transfers*.

