### PR TITLE
rsync: Add missing `dirs` long option

### DIFF
--- a/support/rrsync
+++ b/support/rrsync
@@ -60,6 +60,7 @@ long_opts = {
   'delete-during': 0,
   'delete-excluded': 0,
   'delete-missing-args': 0,
+  'dirs': 0,
   'existing': 0,
   'fake-super': 0,
   'files-from': 3,


### PR DESCRIPTION
Not sure why this is missing or how it hasn't been noticed until now but this was preventing me from using `rsync -d` (or `-a/-r`) with `rrsync`.

My client was sending `rsync --server -r -v -v -v --dirs . /path` and the `.` was getting intercepted by `--dirs`, leading to `/usr/bin/rrsync error: invalid rsync-command syntax or options`.