### PR TITLE
fix signed integer overflow in proxy protocol v2 header parsing

### DIFF
--- a/clientname.c
+++ b/clientname.c
@@ -167,7 +167,7 @@ int read_proxy_protocol_header(int fd)
 			char sig[PROXY_V2_SIG_SIZE];
 			char ver_cmd;
 			char fam;
-			char len[2];
+			unsigned char len[2];
 			union {
 				struct {
 					char src_addr[4];


### PR DESCRIPTION
The len field in the proxy v2 header was declared as signed char, allowing a negative size to bypass the validation check and cause a stack buffer overflow when passed to read_buf() as size_t.

This bug was reported by John Walker from ZeroPath, many thanks for the clear report!

With the current code this bug does not represent a security issue as it only results in the exit of the forked process that is specific to the attached client, so it is equivalent to the client closing the socket, so no CVE for this, but it is good to fix it to prevent a future issue.