### PR TITLE
xattrs: fixed count in qsort

### DIFF
--- a/xattrs.c
+++ b/xattrs.c
@@ -860,8 +860,8 @@ void receive_xattr(int f, struct file_struct *file)
 		rxa->num = num;
 	}
 
-	if (need_sort && count > 1)
-		qsort(temp_xattr.items, count, sizeof (rsync_xa), rsync_xal_compare_names);
+	if (need_sort && temp_xattr.count > 1)
+		qsort(temp_xattr.items, temp_xattr.count, sizeof (rsync_xa), rsync_xal_compare_names);
 
 	ndx = rsync_xal_store(&temp_xattr); /* adds item to rsync_xal_l */
 


### PR DESCRIPTION
this fixes the count passed to the sort of the xattr list. This issue was reported here:

https://www.openwall.com/lists/oss-security/2026/04/16/2

the bug is not exploitable due to the fork-per-connection design of rsync, the attack is the equivalent of the user closing the socket themselves.

fixes #871 