### PR TITLE
testsuite/xattrs: ignore SUNWattr_* in the Solaris xls helper

### DIFF
--- a/.github/workflows/solaris-build.yml
+++ b/.github/workflows/solaris-build.yml
@@ -34,11 +34,6 @@ jobs:
           ./configure --with-rrsync -disable-zstd --disable-md2man --disable-xxhash --disable-lz4
           make
           ./rsync --version
-          cat > testsuite/xattrs.test <<'EOF'
-          #!/bin/sh
-          . $suitedir/rsync.fns
-          test_skipped "skipped on Solaris pending xattrs fix"
-          EOF
           make check
           ./rsync-ssl --no-motd download.samba.org::rsyncftp/ || true
     - name: save artifact

--- a/testsuite/xattrs.test
+++ b/testsuite/xattrs.test
@@ -38,7 +38,10 @@ EOF
     xls() {
 	for fn in "${@}"; do
 	    runat "$fn" "$SHELL_PATH" <<EOF
-for x in *; do echo "\$x=\`cat \$x\`"; done
+for x in *; do
+    case "\$x" in SUNWattr_*) continue;; esac
+    echo "\$x=\`cat \$x\`"
+done
 EOF
        done
     }


### PR DESCRIPTION
The Solaris xls() function listed every entry in the file's xattr directory, which on Solaris includes OS-managed SUNWattr_ro and SUNWattr_rw pseudo-attributes. SUNWattr_rw embeds the file creation time, so its bytes naturally differ between the source and destination files, making the xattrs and xattrs-hlink tests fail with diffs that have nothing to do with rsync.

Rsync's own listxattr wrapper already filters these out (lib/sysxattrs.c), so the right fix is to filter them in the test display too. Other platforms are unaffected because each has its own xls() branch in the case statement.

With the test now actually passing on Solaris, drop the CI hack that overwrote testsuite/xattrs.test with a skip stub.