### PR TITLE
rrsync: add -absolute argument to support calling rsync with absolute…

### DIFF
--- a/support/rrsync
+++ b/support/rrsync
@@ -302,12 +302,12 @@ def validated_arg(opt, arg, typ=3, wild=False):
     if arg.startswith('./'):
         arg = arg[1:]
     arg = arg.replace('//', '/')
-    arg = arg.lstrip('/')
+    is_absolute_arg = args.absolute and opt == 'arg' and args.dir != '/' and (arg == args.dir or arg.startswith(args.dir_slash))
+    if not is_absolute_arg:
+        arg = arg.lstrip('/')
     if args.dir != '/':
         if HAS_DOT_DOT_RE.search(arg):
             die("do not use .. in", opt, "(anchor the path at the root of your restricted dir)")
-        if arg.startswith('/'):
-            arg = args.dir + arg
 
     if wild:
         got = glob.glob(arg)
@@ -328,12 +328,15 @@ def validated_arg(opt, arg, typ=3, wild=False):
                     arg = arg[:-2]
             real_arg = os.path.realpath(arg)
             if arg != real_arg and not real_arg.startswith(args.dir_slash):
-                die('unsafe arg:', orig_arg, [arg, real_arg])
+                if not (is_absolute_arg and real_arg == args.dir):
+                    die('unsafe arg:', orig_arg, [arg, real_arg])
             if arg_has_trailing_slash:
                 arg += '/'
             elif arg_has_trailing_slash_dot:
                 arg += '/.'
-            if opt == 'arg' and arg.startswith(args.dir_slash):
+            if is_absolute_arg and arg == args.dir:
+                arg = '.'
+            elif opt == 'arg' and arg.startswith(args.dir_slash):
                 arg = arg[args.dir_slash_len:]
                 if arg == '':
                     arg = '.'
@@ -372,6 +375,7 @@ if __name__ == '__main__':
     only_group.add_argument('-ro', action='store_true', help="Allow only reading from the DIR. Implies -no-del and -no-lock.")
     only_group.add_argument('-wo', action='store_true', help="Allow only writing to the DIR.")
     arg_parser.add_argument('-munge', action='store_true', help="Enable rsync's --munge-links on the server side.")
+    arg_parser.add_argument('-absolute', action='store_true', help="Allow transfer args to use absolute server paths under DIR.")
     arg_parser.add_argument('-no-del', action='store_true', help="Disable rsync's --delete* and --remove* options.")
     arg_parser.add_argument('-no-lock', action='store_true', help="Avoid the single-run (per-user) lock check.")
     arg_parser.add_argument('-no-overwrite', action='store_true', help="Prevent overwriting existing files by enforcing --ignore-existing")

--- a/support/rrsync.1.md
+++ b/support/rrsync.1.md
@@ -5,7 +5,7 @@ rrsync - a script to setup restricted rsync users via ssh logins
 ## SYNOPSIS
 
 ```
-rrsync [-ro|-wo] [-munge] [-no-del] [-no-lock] [-no-overwrite]  DIR
+rrsync [-ro|-wo] [-munge] [-absolute] [-no-del] [-no-lock] [-no-overwrite] DIR
 ```
 
 The single non-option argument specifies the restricted _DIR_ to use. It can be
@@ -76,6 +76,12 @@ The remainder of this manpage is dedicated to using the rrsync script.
 0.  `-munge`
 
     Enable rsync's [`--munge-links`](rsync.1#opt) on the server side.
+
+0. `-absolute`
+
+    Allow file-transfer arguments to name the restricted directory using its
+    absolute server path. For example, with `rrsync -absolute /path/to/root`,
+    the transfer arg `/path/to/root/dir1` is accepted as an alias for `dir1`.
 
 0.  `-no-del`
 


### PR DESCRIPTION
I noticed unreachable code in `rrsync`. Instead of just cleaning it up, I thought I would also add a nice new feature.

Clean up
-----------------------

Line 305:

```
    arg = arg.lstrip('/')
    if args.dir != '/':
        if HAS_DOT_DOT_RE.search(arg):
            die("do not use .. in", opt, "(anchor the path at the root of your restricted dir)")
        if arg.startswith('/'):
            arg = args.dir + arg
```

The last 2 lines are never called because `arg.lstrip('/')` ensure the condition is never true (lstrip removes multiple instances if needed)

New feature: motivation
-----------------------
rsync supports only relative path. This is good for security, it avoids shenanigans with symlinks or other prefix tricks. However, this is not convenient to the user, because the client needs to be aware of what the `DIR` argument for `rrsync` is. It means that in some sense `rrsync` makes it not backward compatible.

If I have all my client code running `rsync`, and I decide later to add `rrsync` to increase security, then I have to modify all my client code to change relative paths instead.

If even later I decide to change `DIR`, to a more or less restricted entry, then again I have to modify all my client code.

This is not logical because the clients should only be aware of what they want to `rsync`, they should not have to know what restrictions are imposed on them

New feature: implementation
-----------------------
I tried to minimize the number of lines of code, so you (mainteners) probably don't need too much of an explanation. I'll just mention that I tried to make sure my patch was as secure as possible. The main mechanism is that I am not changing the logic. Even when we pass an absolute path, `rrsync` still passes the relative path to `rsync`. So on the server I am  NOT actually resolving the absolute path (it's still invoked exactly like in the current version). That makes it resistant to trying to escape the `rrsync` DIR, no symlink escape, no prefix trick.

I also wanted to make sure this is 100% backward compatible. It would have been natural to just check if the given path is an absolute path. However, the current behaviour of rrsync is to append a given absolute path to the `DIR`. I would argue absolute path should be respected, and `rrsync` should actually error out in that scenario. However, I suspect you might not want to change that behaviour, so I just added a new argument.

New feature: usage
-----------------------
On the server:
     `ForceCommand rrsync -absolute /path/to/restricted/`
 
On the client
     `rsync user@host:/path/to/restricted/dir .`


Let me know what you think. Happy to make any change as you see fit, if that helps.

Testing
--------
I tested on my end on OpenBSD and macOS, and it worked correctly.