### PR TITLE
ci: add Ubuntu 22.04 and AlmaLinux 8 workflows for backporting

### DIFF
--- a/.github/workflows/almalinux-8-build.yml
+++ b/.github/workflows/almalinux-8-build.yml
@@ -1,0 +1,73 @@
+name: Test rsync on AlmaLinux 8
+
+# Older-LTS coverage on the Fedora/RHEL family to help with backporting
+# security fixes. AlmaLinux 8 is the RHEL 8 rebuild and is the oldest
+# active LTS in this family (RHEL 8 full support runs to 2029).
+# GitHub Actions has no native runner for this family, so the job runs
+# inside an almalinux:8 container hosted on ubuntu-latest.
+
+on:
+  push:
+    branches: [ master ]
+    paths-ignore:
+      - '.github/workflows/*.yml'
+      - '!.github/workflows/almalinux-8-build.yml'
+  pull_request:
+    branches: [ master ]
+    paths-ignore:
+      - '.github/workflows/*.yml'
+      - '!.github/workflows/almalinux-8-build.yml'
+  schedule:
+    - cron: '42 8 * * *'
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    container:
+      image: almalinux:8
+    name: Test rsync on AlmaLinux 8
+    steps:
+    - name: install git
+      # actions/checkout needs git in the container before the checkout step.
+      run: dnf -y install git
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+    - name: prep
+      # PowerTools is needed for libzstd-devel etc; xxhash and lz4 dev
+      # headers live in EPEL on RHEL 8.
+      run: |
+        dnf -y install epel-release
+        dnf config-manager --set-enabled powertools
+        dnf -y install gcc gcc-c++ make autoconf automake m4 \
+            python3 python3-pip diffutils \
+            openssl openssl-devel \
+            attr libattr-devel acl libacl-devel \
+            zstd libzstd-devel \
+            lz4 lz4-devel \
+            xxhash xxhash-devel
+        pip3 install commonmark
+    - name: configure
+      run: ./configure --with-rrsync
+    - name: make
+      run: make
+    - name: info
+      run: ./rsync --version
+    - name: check
+      # In the container we already run as root, so no sudo. The
+      # crtimes-not-supported skip matches the other Linux jobs.
+      run: RSYNC_EXPECT_SKIPPED=crtimes make check
+    - name: ssl file list
+      run: ./rsync-ssl --no-motd download.samba.org::rsyncftp/ || true
+    - name: save artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: almalinux-8-bin
+        path: |
+          rsync
+          rsync-ssl
+          rsync.1
+          rsync-ssl.1
+          rsyncd.conf.5
+          rrsync.1
+          rrsync

--- a/.github/workflows/almalinux-8-build.yml
+++ b/.github/workflows/almalinux-8-build.yml
@@ -35,17 +35,21 @@ jobs:
         fetch-depth: 0
     - name: prep
       # PowerTools is needed for libzstd-devel etc; xxhash and lz4 dev
-      # headers live in EPEL on RHEL 8.
+      # headers live in EPEL on RHEL 8. The default python3 on RHEL 8
+      # is 3.6, which is too old for runtests.py (uses capture_output=
+      # / text= introduced in 3.7), so install python39 and point
+      # /usr/bin/python3 at it.
       run: |
         dnf -y install epel-release
         dnf config-manager --set-enabled powertools
         dnf -y install gcc gcc-c++ make autoconf automake m4 \
-            python3 python3-pip diffutils \
+            python39 python39-pip diffutils \
             openssl openssl-devel \
             attr libattr-devel acl libacl-devel \
             zstd libzstd-devel \
             lz4 lz4-devel \
             xxhash xxhash-devel
+        alternatives --set python3 /usr/bin/python3.9
         pip3 install commonmark
     - name: configure
       run: ./configure --with-rrsync

--- a/.github/workflows/ubuntu-22.04-build.yml
+++ b/.github/workflows/ubuntu-22.04-build.yml
@@ -1,0 +1,60 @@
+name: Test rsync on Ubuntu 22.04
+
+# Older-LTS coverage to help with backporting security fixes. ubuntu-22.04
+# is currently the oldest GitHub Actions runner image (20.04 was retired
+# in April 2025).
+
+on:
+  push:
+    branches: [ master ]
+    paths-ignore:
+      - '.github/workflows/*.yml'
+      - '!.github/workflows/ubuntu-22.04-build.yml'
+  pull_request:
+    branches: [ master ]
+    paths-ignore:
+      - '.github/workflows/*.yml'
+      - '!.github/workflows/ubuntu-22.04-build.yml'
+  schedule:
+    - cron: '42 8 * * *'
+
+jobs:
+  test:
+    runs-on: ubuntu-22.04
+    name: Test rsync on Ubuntu 22.04
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+    - name: prep
+      run: |
+        sudo apt-get install acl libacl1-dev attr libattr1-dev liblz4-dev libzstd-dev libxxhash-dev python3-cmarkgfm openssl
+        echo "/usr/local/bin" >>$GITHUB_PATH
+    - name: configure
+      run: ./configure --with-rrsync
+    - name: make
+      run: make
+    - name: install
+      run: sudo make install
+    - name: info
+      run: rsync --version
+    - name: check
+      run: sudo RSYNC_EXPECT_SKIPPED=crtimes make check
+    - name: check30
+      run: sudo RSYNC_EXPECT_SKIPPED=crtimes make check30
+    - name: check29
+      run: sudo RSYNC_EXPECT_SKIPPED=crtimes make check29
+    - name: ssl file list
+      run: rsync-ssl --no-motd download.samba.org::rsyncftp/ || true
+    - name: save artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: ubuntu-22.04-bin
+        path: |
+          rsync
+          rsync-ssl
+          rsync.1
+          rsync-ssl.1
+          rsyncd.conf.5
+          rrsync.1
+          rrsync


### PR DESCRIPTION
The intent is to validate that future security fixes still build and test cleanly on the oldest still-supported LTS releases of the two mainstream Linux families, so backports can be developed against the same CI surface as the trunk:

  - ubuntu-22.04: oldest GitHub Actions runner image still available (20.04 was retired in April 2025). Mirrors the existing ubuntu-build.yml step list.
  - almalinux-8: RHEL 8 rebuild, full support until 2029. Runs in an almalinux:8 container on ubuntu-latest because GHA has no native runner for the Fedora/RHEL family. Pulls libzstd/xxhash/lz4 dev headers from PowerTools + EPEL; commonmark via pip for the man page generator.

Both jobs follow the same paths-ignore convention as the other workflows so a workflow-only change to one file won't fan out across the whole CI matrix.