### PR TITLE
docs: add rsync Discord server link

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,15 @@ details.
 [3]: https://rsync.samba.org/lists.html
 
 
+DISCORD
+-------
+
+There is also an rsync [Discord server][d] for real-time chat about rsync
+and its development.
+
+[d]: https://discord.gg/Avfvy9zhdp
+
+
 BUG REPORTS
 -----------
 

--- a/rsync-web/lists.html
+++ b/rsync-web/lists.html
@@ -63,4 +63,12 @@
       subscription using the web interface.
     </p>
 
+    <H2 align="center">rsync Discord server</H2>
+
+    <p>
+      If you prefer real-time chat, there is also an rsync
+      <a href="https://discord.gg/Avfvy9zhdp">Discord server</a> for
+      discussion about rsync and its development.
+    </p>
+
 <!--#include virtual="footer.html" -->


### PR DESCRIPTION
Add a link to the rsync Discord server (https://discord.gg/Avfvy9zhdp) below the mailing lists section in README.md and on the lists.html web page.