### PR TITLE
ci: clean up workflow shellcheck nits

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -1,0 +1,43 @@
+name: Lint GitHub Actions workflows
+
+# Static-check the workflow YAML with rhysd/actionlint.  Catches missing
+# secrets, bad expressions, expression-type errors, unsupported runner
+# images, and (via embedded shellcheck) common pitfalls in `run:` scripts.
+# Trigger only on changes under .github/workflows/ so the rest of the
+# matrix isn't billed when nothing here moves.
+
+on:
+  push:
+    branches: [ master ]
+    paths:
+      - '.github/workflows/*.yml'
+      - '.github/actionlint.yaml'
+      - '.github/actionlint.yml'
+  pull_request:
+    branches: [ master ]
+    paths:
+      - '.github/workflows/*.yml'
+      - '.github/actionlint.yaml'
+      - '.github/actionlint.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  actionlint:
+    runs-on: ubuntu-latest
+    name: actionlint
+    steps:
+      - uses: actions/checkout@v4
+      - name: install actionlint
+        # Pin a version so this job is reproducible; bump deliberately.
+        # The download script verifies a SHA256 of the release tarball.
+        run: |
+          bash <(curl --proto '=https' --tlsv1.2 -fsSL \
+              https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash) \
+              1.7.12
+          echo "$PWD" >>"$GITHUB_PATH"
+      - name: actionlint --version
+        run: actionlint -version
+      - name: actionlint .github/workflows/*.yml
+        run: actionlint -color

--- a/.github/workflows/almalinux-8-build.yml
+++ b/.github/workflows/almalinux-8-build.yml
@@ -65,7 +65,7 @@ jobs:
       run: RSYNC_EXPECT_SKIPPED=crtimes,daemon-access-ip,daemon-chroot-acl,proxy-response-line-too-long make check
     - name: check (TCP daemon transport)
       # Second run exercising the real loopback-TCP daemon path.
-      run: ./runtests.py --rsync-bin=`pwd`/rsync --use-tcp -j 8
+      run: ./runtests.py --rsync-bin="$PWD/rsync" --use-tcp -j 8
     - name: ssl file list
       run: ./rsync-ssl --no-motd download.samba.org::rsyncftp/ || true
     - name: save artifact

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -27,7 +27,7 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get install -y acl libacl1-dev attr libattr1-dev liblz4-dev libzstd-dev libxxhash-dev python3-cmarkgfm openssl gcovr
-        echo "/usr/local/bin" >>$GITHUB_PATH
+        echo "/usr/local/bin" >>"$GITHUB_PATH"
     - name: configure
       run: ./configure --enable-coverage --with-rrsync
     - name: make

--- a/.github/workflows/macos-build.yml
+++ b/.github/workflows/macos-build.yml
@@ -26,7 +26,7 @@ jobs:
       run: |
         brew install automake openssl xxhash zstd lz4
         pip3 install --user --break-system-packages commonmark
-        echo "$(brew --prefix)/bin" >>$GITHUB_PATH
+        echo "$(brew --prefix)/bin" >>"$GITHUB_PATH"
     - name: configure
       run: |
         BREW_PREFIX=$(brew --prefix)
@@ -48,7 +48,7 @@ jobs:
     - name: check (TCP daemon transport)
       # Second run with daemon tests over a real loopback rsyncd; the default
       # 'make check' above uses the secure stdio-pipe transport.
-      run: sudo ./runtests.py --rsync-bin=`pwd`/rsync --use-tcp -j 8
+      run: sudo ./runtests.py --rsync-bin="$PWD/rsync" --use-tcp -j 8
     - name: ssl file list
       run: rsync-ssl --no-motd download.samba.org::rsyncftp/ || true
     - name: save artifact

--- a/.github/workflows/ubuntu-22.04-build.yml
+++ b/.github/workflows/ubuntu-22.04-build.yml
@@ -29,7 +29,7 @@ jobs:
     - name: prep
       run: |
         sudo apt-get install acl libacl1-dev attr libattr1-dev liblz4-dev libzstd-dev libxxhash-dev python3-cmarkgfm openssl
-        echo "/usr/local/bin" >>$GITHUB_PATH
+        echo "/usr/local/bin" >>"$GITHUB_PATH"
     - name: configure
       run: ./configure --with-rrsync
     - name: make
@@ -47,7 +47,7 @@ jobs:
     - name: check (TCP daemon transport)
       # Second run with daemon tests over a real loopback rsyncd; the default
       # 'make check' above uses the secure stdio-pipe transport.
-      run: sudo ./runtests.py --rsync-bin=`pwd`/rsync --use-tcp -j 8
+      run: sudo ./runtests.py --rsync-bin="$PWD/rsync" --use-tcp -j 8
     - name: ssl file list
       run: rsync-ssl --no-motd download.samba.org::rsyncftp/ || true
     - name: save artifact

--- a/.github/workflows/ubuntu-build.yml
+++ b/.github/workflows/ubuntu-build.yml
@@ -25,7 +25,7 @@ jobs:
     - name: prep
       run: |
         sudo apt-get install acl libacl1-dev attr libattr1-dev liblz4-dev libzstd-dev libxxhash-dev python3-cmarkgfm openssl
-        echo "/usr/local/bin" >>$GITHUB_PATH
+        echo "/usr/local/bin" >>"$GITHUB_PATH"
     - name: configure
       run: ./configure --with-rrsync
     - name: make
@@ -45,7 +45,7 @@ jobs:
       # 'make check' above uses the secure stdio-pipe transport (no listening
       # sockets); this run exercises the real TCP accept/auth path. Skip-set
       # is env-dependent here (chroot-acl), so leave RSYNC_EXPECT_SKIPPED unset.
-      run: sudo ./runtests.py --rsync-bin=`pwd`/rsync --use-tcp -j 8
+      run: sudo ./runtests.py --rsync-bin="$PWD/rsync" --use-tcp -j 8
     - name: ssl file list
       run: rsync-ssl --no-motd download.samba.org::rsyncftp/ || true
     - name: save artifact


### PR DESCRIPTION
actionlint (rhysd/actionlint) reported a handful of shellcheck-class issues across the GitHub Actions workflows.  All are 1-line mechanical fixes:

  * Replace legacy backticks in --rsync-bin=`pwd`/rsync with --rsync-bin="$PWD/rsync" (SC2006 + SC2046; almalinux-8-build, macos-build, ubuntu-22.04-build, ubuntu-build).
  * Quote >>$GITHUB_PATH redirects as >>"$GITHUB_PATH" (SC2086; coverage, macos-build, ubuntu-22.04-build, ubuntu-build).

After this commit `actionlint .github/workflows/*.yml` exits 0.

(Also cleaned up 6 editor backup *.yml~ files from the local working tree; those weren't tracked -- *~ is gitignored -- so the cleanup is local-only and not part of this commit.)