### PR TITLE
Run test suite in emulator as part of Android build workflow

### DIFF
--- a/.github/workflows/android-static-build.yml
+++ b/.github/workflows/android-static-build.yml
@@ -1,13 +1,11 @@
-name: Build static rsync for Android
+name: Test rsync on Android
 
 # Cross-compiles statically-linked rsync binaries with the Android NDK,
 # suitable for dropping onto a phone (adb push / Termux) with no shared
 # libraries. arm64-v8a covers all modern phones; armeabi-v7a covers older
 # 32-bit devices. The binaries are uploaded as workflow artifacts.
 #
-# These are cross-compiled, so the test suite can't run here; we sanity
-# check that each binary is the right architecture, is static, and that
-# it executes (`--version`) under qemu-user.
+# Run the test suite within Termux under the Android Emulator.
 
 on:
   push:
@@ -43,6 +41,8 @@ jobs:
           - abi: armeabi-v7a     # older 32-bit phones
             triple: armv7a-linux-androideabi
             qemu: qemu-arm-static
+          - abi: x86_64
+            triple: x86_64-linux-android
     steps:
       - uses: actions/checkout@v4
         with:
@@ -89,6 +89,7 @@ jobs:
           "$STRIP" rsync
 
       - name: Verify binary
+        if: matrix.abi != 'x86_64'
         shell: bash
         run: |
           set -euo pipefail
@@ -101,6 +102,24 @@ jobs:
           # Best-effort: confirm it actually runs under qemu-user.
           ${{ matrix.qemu }} ./rsync --version | head -3 || \
             echo "WARNING: qemu smoke test did not run cleanly (check on a real device)"
+
+      - name: Enable hardware acceleration for emulator
+        if: matrix.abi == 'x86_64'
+        run: echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666",
+                   OPTIONS+="static_node=kvm"'
+                | sudo tee /etc/udev/rules.d/99-kvm4all.rules;
+          sudo udevadm control --reload-rules;
+          sudo udevadm trigger --name-match=kvm
+
+      - name: Run Tests
+        if: matrix.abi == 'x86_64'
+        uses: reactivecircus/android-emulator-runner@e89f39f1abbbd05b1113a29cf4db69e7540cae5a
+        with:
+          api-level: 30
+          arch: x86_64
+          script: make check
+        env:
+          GH_TOKEN: ${{ github.token }}
 
       - name: Package
         shell: bash

--- a/Makefile.in
+++ b/Makefile.in
@@ -381,7 +381,12 @@ check-progs: all $(CHECK_PROGS) $(CHECK_SYMLINKS)
 
 .PHONY: check
 check: all $(CHECK_PROGS) $(CHECK_SYMLINKS)
-	$(srcdir)/runtests.py --rsync-bin=`pwd`/rsync$(EXEEXT) -j $(CHECK_J)
+	@case "@cross_compiling@-@host_os@" in \
+	yes-*android*) \
+	  $(srcdir)/test-android -j $(CHECK_J) ;; \
+	*) \
+	  $(srcdir)/runtests.py --rsync-bin=`pwd`/rsync$(EXEEXT) -j $(CHECK_J) ;; \
+	esac
 
 .PHONY: check29
 check29: all $(CHECK_PROGS) $(CHECK_SYMLINKS)

--- a/configure.ac
+++ b/configure.ac
@@ -1325,6 +1325,8 @@ AC_SUBST(MAKE_RRSYNC)
 AC_SUBST(MAKE_RRSYNC_1)
 AC_SUBST(GEN_RRSYNC)
 AC_SUBST(MAKE_MAN)
+AC_SUBST(cross_compiling)
+AC_SUBST(host_os)
 
 AC_CHECK_FUNCS(_acl __acl _facl __facl)
 #################################################

--- a/test-android
+++ b/test-android
@@ -1,0 +1,46 @@
+#!/bin/sh -e
+
+# Copyright © 2026 Matt Robinson
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+if [ $# -eq 0 ]; then
+    echo 'A list of helper names was expected' >&2
+    exit 1
+fi
+
+if ! adb -e get-state > /dev/null 2>&1; then
+    echo 'Unable to find a running Android emulator' >&2
+    exit 1
+fi
+
+if [ -z "$(adb shell pm list packages com.termux)" ]; then
+    tempdir=$(mktemp -d)
+    trap 'rm -rf "$tempdir"' EXIT
+
+    gh release download --repo termux/termux-app  --dir "$tempdir" \
+        --pattern 'termux-app_v*-debug_x86_64.apk'
+    adb install "$tempdir"/termux-app_*.apk
+
+    # Launch Termux so that it bootstraps the environment
+    adb shell monkey -p com.termux 1
+
+    # termux.properties appears to be created at the end of the bootstrapping
+    until adb shell run-as com.termux \
+            test -f files/home/.termux/termux.properties; do
+        sleep 1
+    done
+fi
+
+tar -c --exclude-vcs --exclude-backup --exclude="*.o" . | \
+    adb shell run-as com.termux sh -c "'cat > files/home/transfer.tar'"
+
+adb shell run-as com.termux files/usr/bin/bash -le <<EOF
+export PATH=\$(pwd)/files/usr/bin:\$PATH
+export LD_PRELOAD=\$(pwd)/files/usr/lib/libtermux-exec.so
+export HOME=\$(pwd)/files/home
+cd
+command -v python > /dev/null || pkg install -y --no-install-recommends python
+tar -xf transfer.tar
+python ./runtests.py "$@"
+EOF

--- a/testsuite/alt-dest-deep_test.py
+++ b/testsuite/alt-dest-deep_test.py
@@ -23,7 +23,7 @@ import os
 from rsyncfns import (
     FROMDIR, SCRATCHDIR, TODIR,
     assert_exists, assert_hardlinked, assert_not_exists, assert_not_hardlinked,
-    assert_same, make_tree, rmtree, run_rsync, walk_files,
+    assert_same, hardlinks_supported, make_tree, rmtree, run_rsync, walk_files,
 )
 
 src = FROMDIR
@@ -55,14 +55,15 @@ def run_to(opt):
 
 
 # --- --link-dest: unchanged -> hardlink to ref; changed -> fresh copy -------
-run_to('link-dest')
-for rel in rels:
-    d, r = TODIR / rel, ref / rel
-    if str(rel) == changed:
-        assert_not_hardlinked(d, r, label=f'link-dest changed {rel}')
-        assert_same(d, src / rel, label=f'link-dest changed {rel}')
-    else:
-        assert_hardlinked(d, r, label=f'link-dest unchanged {rel}')
+if hardlinks_supported():
+    run_to('link-dest')
+    for rel in rels:
+        d, r = TODIR / rel, ref / rel
+        if str(rel) == changed:
+            assert_not_hardlinked(d, r, label=f'link-dest changed {rel}')
+            assert_same(d, src / rel, label=f'link-dest changed {rel}')
+        else:
+            assert_hardlinked(d, r, label=f'link-dest unchanged {rel}')
 
 # --- --copy-dest: every file copied (never linked), dest complete -----------
 run_to('copy-dest')

--- a/testsuite/hands_test.py
+++ b/testsuite/hands_test.py
@@ -10,7 +10,8 @@
 import os
 import shutil
 
-from rsyncfns import FROMDIR, TMPDIR, TODIR, checkit, hands_setup, run_rsync
+from rsyncfns import (FROMDIR, TMPDIR, TODIR, checkit, hands_setup,
+                      hardlinks_supported, run_rsync)
 
 
 hands_setup()
@@ -23,8 +24,11 @@ print("Test basic operation:")
 checkit(['-av', f'{FROMDIR}/', str(TODIR)], FROMDIR, TODIR)
 
 # 2. hard links — link filelist into dir/ then transfer with -H so the
-# receiver should recreate the link relationship.
-os.link(FROMDIR / 'filelist', FROMDIR / 'dir' / 'filelist')
+# receiver should recreate the link relationship. Skip just this step
+# where hard links aren't available (e.g. Android/Termux); the -H
+# transfer below is still a valid no-op there.
+if hardlinks_supported():
+    os.link(FROMDIR / 'filelist', FROMDIR / 'dir' / 'filelist')
 print("Test hard links:")
 checkit(['-avH', '--bwlimit=0', DEBUG_OPTS, f'{FROMDIR}/', str(TODIR)], FROMDIR, TODIR)
 

--- a/testsuite/hardlinks-deep_test.py
+++ b/testsuite/hardlinks-deep_test.py
@@ -10,7 +10,8 @@ independent inodes.
 
 from rsyncfns import (
     FROMDIR, TODIR,
-    assert_hardlinked, assert_not_hardlinked, makepath, rmtree, run_rsync,
+    assert_hardlinked, assert_not_hardlinked, make_hardlink, makepath, rmtree,
+    run_rsync, test_skipped,
 )
 import os
 
@@ -22,7 +23,11 @@ rmtree(src)
 rmtree(TODIR)
 makepath(src / 'a' / 'aa', src / 'b' / 'bb')
 (src / a).write_text("shared content across directories\n")
-os.link(src / a, src / b)            # one inode, two names in different dirs
+
+try:
+    make_hardlink(src / a, src / b) # one inode, two names in different dirs
+except OSError:
+    test_skipped("Can't create hardlink")
 
 # -H preserves the cross-directory hard link.
 run_rsync('-aH', f'{src}/', f'{TODIR}/')

--- a/testsuite/hardlinks_test.py
+++ b/testsuite/hardlinks_test.py
@@ -13,7 +13,7 @@ import subprocess
 
 from rsyncfns import (
     CHKDIR, FROMDIR, OUTFILE, RSYNC, RSYNC_PEER, SRCDIR, TODIR,
-    checkit, makepath, rsync_argv, test_fail, test_skipped,
+    checkit, make_hardlink, makepath, rsync_argv, test_fail, test_skipped,
 )
 
 
@@ -26,11 +26,11 @@ name3 = FROMDIR / 'name3'
 name4 = FROMDIR / 'name4'
 name1.write_text("This is the file\n")
 try:
-    os.link(name1, name2)
+    make_hardlink(name1, name2)
 except OSError:
     test_skipped("Can't create hardlink")
 try:
-    os.link(name2, name3)
+    make_hardlink(name2, name3)
 except OSError:
     test_fail("Can't create hardlink")
 shutil.copy(name2, name4)
@@ -61,7 +61,7 @@ for x in chars:
     for y in chars:
         (cdir / f'{x}{y}').touch()
 
-os.link(name1, FROMDIR / 'subdir' / 'down' / 'deep' / 'new-file')
+make_hardlink(name1, FROMDIR / 'subdir' / 'down' / 'deep' / 'new-file')
 (TODIR / 'text').unlink()
 
 checkit(['-aHivve', SSH, '--debug=HLINK5', f'--rsync-path={RSYNC_PEER}',
@@ -79,7 +79,7 @@ checkit(['-aHivv', '--debug=HLINK5', f'--copy-dest={TODIR}',
 # stays single-linked -- and re-sync with --checksum.
 (FROMDIR / 'solo').write_text("This is another file\n")
 try:
-    os.link(FROMDIR / 'solo', CHKDIR / 'solo')
+    make_hardlink(FROMDIR / 'solo', CHKDIR / 'solo')
 except OSError:
     test_fail("Can't create hardlink")
 

--- a/testsuite/itemize_test.py
+++ b/testsuite/itemize_test.py
@@ -11,7 +11,8 @@ import shutil
 from rsyncfns import (
     CHKFILE, FROMDIR, RSYNC, SCRATCHDIR, SRCDIR, TMPDIR, TODIR,
     all_plus, allspace, dots,
-    checkdiff, cp_p, makepath, run_rsync, v_filt,
+    checkdiff, cp_p, hardlinks_supported, makepath, run_rsync, test_skipped,
+    v_filt,
 )
 
 
@@ -31,6 +32,10 @@ try:
 finally:
     os.umask(old_umask)
 
+# The expected itemized output below assumes the 'extra' hard link
+# exists, so skip the whole test where hard links aren't available.
+if not hardlinks_supported():
+    test_skipped("hard links not supported on this filesystem")
 os.link(FROMDIR / 'foo' / 'config1', FROMDIR / 'foo' / 'extra')
 if to2dir.is_file():
     to2dir.unlink()

--- a/testsuite/protected-regular_test.py
+++ b/testsuite/protected-regular_test.py
@@ -16,10 +16,12 @@ from rsyncfns import TMPDIR, run_rsync, test_fail, test_skipped
 
 
 pr_path = Path('/proc/sys/fs/protected_regular')
-if not pr_path.is_file():
-    test_skipped("Can't find protected_regular setting (only available on Linux)")
-
+# is_file() and read_text() can both raise (e.g. PermissionError when an
+# app sandbox such as Android/Termux denies access to /proc/sys); treat
+# any OSError as "can't determine the setting" and skip.
 try:
+    if not pr_path.is_file():
+        test_skipped("Can't find protected_regular setting (only available on Linux)")
     pr_lvl = pr_path.read_text().strip()
 except OSError:
     test_skipped("Can't check if fs.protected_regular is enabled")

--- a/testsuite/relative_test.py
+++ b/testsuite/relative_test.py
@@ -12,7 +12,7 @@ import time
 
 from rsyncfns import (
     CHKDIR, FROMDIR, OUTFILE, TMPDIR, TODIR,
-    checkit, hands_setup, makepath, rsync_argv,
+    checkit, hands_setup, hardlinks_supported, makepath, rsync_argv,
     run_rsync, test_fail,
 )
 
@@ -59,8 +59,11 @@ checkit(['-avR', f'./{deepstr}', str(TODIR)], CHKDIR, TODIR)
 
 # Add a hard link inside the source and the chk dir; mirror it on both
 # sides so the --delete pass below doesn't see it as new on either tree.
-os.link(deepdir / 'filelist', deepdir / 'dir' / 'filelist')
-os.link(CHKDIR / deepstr / 'filelist', CHKDIR / deepstr / 'dir' / 'filelist')
+# Where hard links aren't available (e.g. Android/Termux) skip both so
+# the two trees stay symmetric and the rest of the test still runs.
+if hardlinks_supported():
+    os.link(deepdir / 'filelist', deepdir / 'dir' / 'filelist')
+    os.link(CHKDIR / deepstr / 'filelist', CHKDIR / deepstr / 'dir' / 'filelist')
 # Re-touch both dirs so the inner-dir time matches.
 src_t = (deepdir / 'dir').stat().st_mtime
 os.utime(deepdir / 'dir', (src_t, src_t))

--- a/testsuite/rsyncfns.py
+++ b/testsuite/rsyncfns.py
@@ -463,6 +463,47 @@ def make_text_file(path, lines: int = 100) -> 'None':
         f.write(content)
 
 
+_hardlinks_ok = None
+
+
+def hardlinks_supported() -> bool:
+    """Cached check for whether hard links work in the scratch tree.
+
+    Some platforms can't create them: Termux's Python is built without
+    os.link, and Android app storage rejects link(2) outright. Tests that
+    need hard links call this to skip cleanly rather than crash.
+    """
+    global _hardlinks_ok
+    if _hardlinks_ok is not None:
+        return _hardlinks_ok
+    if not hasattr(os, 'link'):
+        _hardlinks_ok = False
+        return _hardlinks_ok
+    SCRATCHDIR.mkdir(parents=True, exist_ok=True)
+    a = SCRATCHDIR / '.hardlink-probe-a'
+    b = SCRATCHDIR / '.hardlink-probe-b'
+    try:
+        a.write_text('probe')
+        b.unlink(missing_ok=True)
+        os.link(a, b)
+        _hardlinks_ok = True
+    except OSError:
+        _hardlinks_ok = False
+    finally:
+        a.unlink(missing_ok=True)
+        b.unlink(missing_ok=True)
+    return _hardlinks_ok
+
+
+def make_hardlink(src, dst) -> 'None':
+    """Create a hard link, raising OSError (never AttributeError) when the
+    platform's Python lacks os.link, so a caller's `except OSError` can
+    treat it the same as a runtime link() failure."""
+    if not hasattr(os, 'link'):
+        raise OSError("os.link is not available on this platform")
+    os.link(src, dst)
+
+
 def get_testuid() -> int:
     return os.getuid()
 


### PR DESCRIPTION
@tridge - inspired by our initial exchange in #901 here is a proof of concept of running the test suite within the Android emulator under Termux as part of the Android build workflow you set up previously.  The script can also be run locally if a build targeting Android has been done and an Android emulator is running (I've made the script skip installing Termux or Python if they are already installed to make it fairly quick to keep running the tests).

~~I need to have a few more passes through the script to make things cleaner and tidier, add some more checks, write a decent commit message etc but I'm happy to chip away at all that stuff over the next few days if this looks like the kind of approach you'd be in favour of?~~

~~As naming things is always difficult, do you think `android-run-tests` is a logical / consistent name for the script and is under `support` a sensible place for it (very happy to change if you have strong feelings otherwise)?~~