### PR TITLE
ci: halve CI artifact retention from 90 to 45 days

### DIFF
--- a/.github/workflows/almalinux-8-build.yml
+++ b/.github/workflows/almalinux-8-build.yml
@@ -71,6 +71,7 @@ jobs:
     - name: save artifact
       uses: actions/upload-artifact@v4
       with:
+        retention-days: 45
         name: almalinux-8-bin
         path: |
           rsync

--- a/.github/workflows/android-static-build.yml
+++ b/.github/workflows/android-static-build.yml
@@ -116,5 +116,6 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
+          retention-days: 45
           name: ${{ env.ARTIFACT_NAME }}
           path: dist/

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -65,6 +65,7 @@ jobs:
       if: always()
       uses: actions/upload-artifact@v4
       with:
+        retention-days: 45
         name: coverage-html
         path: |
           coverage

--- a/.github/workflows/cygwin-build.yml
+++ b/.github/workflows/cygwin-build.yml
@@ -54,6 +54,7 @@ jobs:
     - name: save artifact
       uses: actions/upload-artifact@v4
       with:
+        retention-days: 45
         name: cygwin-bin
         path: |
           rsync.exe

--- a/.github/workflows/freebsd-build.yml
+++ b/.github/workflows/freebsd-build.yml
@@ -40,6 +40,7 @@ jobs:
     - name: save artifact
       uses: actions/upload-artifact@v4
       with:
+        retention-days: 45
         name: freebsd-bin
         path: |
           rsync

--- a/.github/workflows/macos-build.yml
+++ b/.github/workflows/macos-build.yml
@@ -54,6 +54,7 @@ jobs:
     - name: save artifact
       uses: actions/upload-artifact@v4
       with:
+        retention-days: 45
         name: macos-bin
         path: |
           rsync

--- a/.github/workflows/netbsd-build.yml
+++ b/.github/workflows/netbsd-build.yml
@@ -41,6 +41,7 @@ jobs:
     - name: save artifact
       uses: actions/upload-artifact@v4
       with:
+        retention-days: 45
         name: netbsd-bin
         path: |
           rsync

--- a/.github/workflows/openbsd-build.yml
+++ b/.github/workflows/openbsd-build.yml
@@ -50,6 +50,7 @@ jobs:
     - name: save artifact
       uses: actions/upload-artifact@v4
       with:
+        retention-days: 45
         name: openbsd-bin
         path: |
           rsync

--- a/.github/workflows/solaris-build.yml
+++ b/.github/workflows/solaris-build.yml
@@ -40,6 +40,7 @@ jobs:
     - name: save artifact
       uses: actions/upload-artifact@v4
       with:
+        retention-days: 45
         name: solaris-bin
         path: |
           rsync

--- a/.github/workflows/ubuntu-22.04-build.yml
+++ b/.github/workflows/ubuntu-22.04-build.yml
@@ -53,6 +53,7 @@ jobs:
     - name: save artifact
       uses: actions/upload-artifact@v4
       with:
+        retention-days: 45
         name: ubuntu-22.04-bin
         path: |
           rsync

--- a/.github/workflows/ubuntu-build.yml
+++ b/.github/workflows/ubuntu-build.yml
@@ -51,6 +51,7 @@ jobs:
     - name: save artifact
       uses: actions/upload-artifact@v4
       with:
+        retention-days: 45
         name: ubuntu-bin
         path: |
           rsync


### PR DESCRIPTION
GitHub Actions artifact storage is approaching our quota. Each `make`/build job uploads its rsync binary + manpages, the coverage job uploads its full HTML tree, and Android uploads its dist/ -- 11 jobs producing artifacts per PR/push, all kept for the repo default of 90 days.

Set retention-days: 45 explicitly on every upload-artifact step so they expire at half the previous lifetime; older artifacts can still be re-built from the commit if needed. No other workflow behaviour changes.