### PR TITLE
Correct broken test case for decimal numbers in human readable form

### DIFF
--- a/testsuite/output-options_test.py
+++ b/testsuite/output-options_test.py
@@ -108,7 +108,7 @@ make_data_file(src / 'big', 50_000)
 plain = out('-a', '--stats', f'{src}/', f'{TODIR}/').stdout
 rmtree(TODIR)
 human = out('-a', '-h', '--stats', f'{src}/', f'{TODIR}/').stdout
-suffix_re = r'Total file size: [\d.]+[KMG]'
+suffix_re = r'Total file size: [\d.,]+[KMG]'
 if not re.search(suffix_re, human):
     test_fail(f"-h did not use a human-readable unit suffix:\n{human}")
 if re.search(suffix_re, plain):


### PR DESCRIPTION
Problem:
Decimal numbers in human readable form are subject of the locale settings on the host running the software.
Some locales use "," instead of "." for decimal numbers, breaking that test case.

Solution:
Corrected test case broken for locales that uses , instead of . for decimal numbers in human readable form.
The test now also accepts "," in addition to "." for decimal numbers.
