### PR TITLE
fix regressions from recent release

### DIFF
--- a/.github/workflows/cygwin-build.yml
+++ b/.github/workflows/cygwin-build.yml
@@ -43,8 +43,10 @@ jobs:
       # (rsyncfns.py drives xattrs via getfattr/setfattr from the `attr`
       # package installed above), verified on a real Cygwin host. The real
       # chown/devices tests still skip (need root/mknod), as do the
-      # RESOLVE_BENEATH symlink-race tests.
-      run: bash -c 'RSYNC_EXPECT_SKIPPED=acls-default,acls-depth,acls,bare-do-open-symlink-race,chdir-symlink-race,chown,daemon-access-ip,daemon-chroot-acl,devices,dir-sgid,open-noatime,protected-regular,proxy-response-line-too-long,sender-flist-symlink-leak,simd-checksum,symlink-dirlink-basis make check'
+      # RESOLVE_BENEATH symlink-race tests.  symlink-dirlink-basis also now
+      # RUNS (the #915 non-daemon basis open uses a plain do_open, restoring
+      # following an in-tree dir-symlink basis without RESOLVE_BENEATH).
+      run: bash -c 'RSYNC_EXPECT_SKIPPED=acls-default,acls-depth,acls,bare-do-open-symlink-race,chdir-symlink-race,chown,daemon-access-ip,daemon-chroot-acl,devices,dir-sgid,open-noatime,protected-regular,proxy-response-line-too-long,sender-flist-symlink-leak,simd-checksum make check'
     - name: check (TCP daemon transport)
       # Second run with daemon tests over a real loopback rsyncd; the default
       # 'make check' above uses the secure stdio-pipe transport.

--- a/flist.c
+++ b/flist.c
@@ -865,13 +865,18 @@ static struct file_struct *recv_file_entry(int f, struct file_list *flist, int x
 		mode = from_wire_mode(read_int(f));
 		/* Reject modes whose type bits are not one of the standard
 		 * file types; otherwise garbage mode values propagate through
-		 * the file-type checks below unpredictably. */
-		if (!S_ISREG(mode) && !S_ISDIR(mode) && !S_ISLNK(mode)
-		 && !S_ISCHR(mode) && !S_ISBLK(mode)
-		 && !S_ISFIFO(mode) && !S_ISSOCK(mode)) {
+		 * the file-type checks below unpredictably.  mode 0 is the one
+		 * legitimate exception: --delete-missing-args (missing_args==2)
+		 * sends a missing arg as a mode-0 entry (IS_MISSING_FILE), the
+		 * generator's delete signal (#910). */
+		if (mode != 0 || missing_args != 2) {
+		    if (!S_ISREG(mode) && !S_ISDIR(mode) && !S_ISLNK(mode)
+		     && !S_ISCHR(mode) && !S_ISBLK(mode)
+		     && !S_ISFIFO(mode) && !S_ISSOCK(mode)) {
 			rprintf(FERROR, "invalid file mode 0%o for %s [%s]\n",
 				(unsigned)mode, lastname, who_am_i());
 			exit_cleanup(RERR_PROTOCOL);
+		    }
 		}
 	}
 	if (atimes_ndx && !S_ISDIR(mode) && !(xflags & XMIT_SAME_ATIME)) {

--- a/receiver.c
+++ b/receiver.c
@@ -99,6 +99,27 @@ static int updating_basis_or_equiv;
  * Anything else is a straight pass-through that preserves the strict contract. */
 static int secure_basis_open(const char *basedir, const char *relpath, int flags, mode_t mode)
 {
+	extern int am_daemon, am_chrooted;
+
+	/* The confined resolver is only needed for the sanitizing daemon
+	 * (am_daemon && !am_chrooted, i.e. use_secure_symlinks).  Local /
+	 * remote-shell mode has no module boundary, and "use chroot = yes" makes
+	 * the kernel root the boundary, so there an alt-dest basis like
+	 * --link-dest=../01 must resolve against the cwd as a bare open did before
+	 * the hardening (confining it would reject the legitimate sibling "..",
+	 * #915). */
+	if (!am_daemon || am_chrooted) {
+		if (basedir) {
+			char fullpath[MAXPATHLEN];
+			if (pathjoin(fullpath, sizeof fullpath, basedir, relpath) >= sizeof fullpath) {
+				errno = ENAMETOOLONG;
+				return -1;
+			}
+			return do_open(fullpath, flags, mode);
+		}
+		return do_open(relpath, flags, mode);
+	}
+
 	if (!basedir && relpath && *relpath == '/') {
 		const char *slash = strrchr(relpath, '/');
 		const char *leaf = slash + 1;
@@ -859,7 +880,7 @@ int recv_files(int f_in, int f_out, char *local_name)
 				basedir = basis_dir[0];
 				fnamecmp = fname;
 				fnamecmp_type = FNAMECMP_BASIS_DIR_LOW;
-				fd1 = secure_relative_open(basedir, fnamecmp, O_RDONLY, 0);
+				fd1 = secure_basis_open(basedir, fnamecmp, O_RDONLY, 0);
 			}
 		}
 

--- a/runtests.py
+++ b/runtests.py
@@ -31,6 +31,11 @@ import subprocess
 import sys
 import threading
 
+# Share the test exit-code enum with the test helpers. exitcodes.py lives in
+# testsuite/ (next to this script); it has no import-time side effects.
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), 'testsuite'))
+from exitcodes import Exit
+
 
 def parse_args():
     p = argparse.ArgumentParser(description='Run rsync test suite')
@@ -58,6 +63,9 @@ def parse_args():
                    help='Stop after first test failure')
     p.add_argument('--timeout', type=int, default=300, metavar='SECS',
                    help='Per-test timeout in seconds (default: 300)')
+    p.add_argument('--race-timeout', type=float, default=5.0, metavar='SECS',
+                   help='Budget (seconds) a TOCTOU symlink-race test may spend '
+                        'trying to win its race before concluding (default: 5)')
     p.add_argument('--rsync-bin', default=None, metavar='PATH',
                    help='Path to rsync binary (default: ./rsync)')
     p.add_argument('--rsync-bin2', default=None, metavar='PATH',
@@ -242,18 +250,18 @@ def parse_expect_result(path):
                     f"{path}:{lineno}: expected '<testname> "
                     f"<{'|'.join(_VALID_OUTCOMES)}>', got: {raw.rstrip()}\n"
                 )
-                sys.exit(2)
+                sys.exit(Exit.ERROR)
             expect[fields[0]] = fields[1]
     return expect
 
 
 def outcome_of(result):
     """Map a per-test exit code to an outcome string."""
-    if result == 0:
+    if result == Exit.PASS:
         return 'pass'
-    if result == 77:
+    if result == Exit.SKIP:
         return 'skip'
-    if result == 78:
+    if result == Exit.XFAIL:
         return 'xfail'
     return 'fail'
 
@@ -321,7 +329,7 @@ def run_one_test(testscript, testbase, scratchdir, base_env, timeout,
     # Build output text
     output_parts = []
 
-    show_log = always_log or (result not in (0, 77, 78))
+    show_log = always_log or (result not in (Exit.PASS, Exit.SKIP, Exit.XFAIL))
     if show_log:
         output_parts.append(f'----- {testbase} log follows')
         try:
@@ -338,9 +346,9 @@ def run_one_test(testscript, testbase, scratchdir, base_env, timeout,
             output_parts.append(f'----- {testbase} rsyncd.log ends')
 
     skipped_reason = ''
-    if result == 0:
+    if result == Exit.PASS:
         output_parts.append(f'PASS    {testbase}')
-    elif result == 77:
+    elif result == Exit.SKIP:
         whyfile = os.path.join(scratchdir, 'whyskipped')
         try:
             with open(whyfile) as f:
@@ -348,7 +356,7 @@ def run_one_test(testscript, testbase, scratchdir, base_env, timeout,
         except FileNotFoundError:
             pass
         output_parts.append(f'SKIP    {testbase} ({skipped_reason})')
-    elif result == 78:
+    elif result == Exit.XFAIL:
         output_parts.append(f'XFAIL   {testbase}')
     else:
         output_parts.append(f'FAIL    {testbase}')
@@ -407,13 +415,13 @@ def main():
 
     if not os.path.isfile(rsync_bin):
         sys.stderr.write(f"rsync_bin {rsync_bin} is not a file\n")
-        sys.exit(2)
+        sys.exit(Exit.ERROR)
     if not os.path.isfile(rsync_bin2):
         sys.stderr.write(f"rsync_bin2 {rsync_bin2} is not a file\n")
-        sys.exit(2)
+        sys.exit(Exit.ERROR)
     if not os.path.isdir(srcdir):
         sys.stderr.write(f"srcdir {srcdir} is not a directory\n")
-        sys.exit(2)
+        sys.exit(Exit.ERROR)
 
     # Helper programs the test scripts invoke directly. Missing any of these
     # would cause many tests to fail with confusing "not found" errors, so
@@ -430,7 +438,7 @@ def main():
             f"Build them with: make {' '.join(missing)}\n"
             f"or run the full test target: make check\n"
         )
-        sys.exit(2)
+        sys.exit(Exit.ERROR)
 
     testuser = get_testuser()
 
@@ -475,6 +483,7 @@ def main():
         'scratchbase': scratchbase,
         'suitedir': suitedir,
         'TESTRUN_TIMEOUT': str(args.timeout),
+        'race_timeout': str(args.race_timeout),
         'HOME': scratchbase,
         'PYTHONPATH': pythonpath,
     })
@@ -535,34 +544,40 @@ def main():
     passed = 0
     failed = 0
     skipped = 0
+    xfailed = 0
     skipped_list = []
     outcomes = {}  # testbase -> actual outcome string ('pass'/'skip'/'fail'/'xfail')
 
     def process_result(tr):
         """Process a TestResult and update counters. Returns True if the test
         should count as a failure for --stop-on-fail purposes."""
-        nonlocal passed, failed, skipped
+        nonlocal passed, failed, skipped, xfailed
         with _print_lock:
             if tr.output:
                 print(tr.output)
         scratchdir = os.path.join(scratchbase, tr.testbase)
         oc = outcome_of(tr.result)
         outcomes[tr.testbase] = oc
-        if tr.result == 0:
+        if tr.result == Exit.PASS:
             passed += 1
-        elif tr.result == 77:
+        elif tr.result == Exit.SKIP:
             skipped_list.append(tr.testbase)
             skipped += 1
+        elif tr.result == Exit.XFAIL:
+            # XFAIL: an expected failure (a known, documented residual the test
+            # asserts against). Reported distinctly but does NOT fail the suite;
+            # when the underlying issue is fixed the test returns 0 instead.
+            xfailed += 1
         else:
             failed += 1
-        if tr.result in (0, 77) and not args.preserve_scratch \
+        if tr.result in (Exit.PASS, Exit.SKIP, Exit.XFAIL) and not args.preserve_scratch \
                 and os.path.isdir(scratchdir):
             subprocess.run(['rm', '-rf', scratchdir], capture_output=True)
         # With a manifest, only a mismatch is a "failure" (an expected fail is
-        # fine); without one, any non-pass/non-skip result is a failure.
+        # fine); without one, any non-pass/non-skip/non-xfail result is a failure.
         if expect is not None:
             return mismatch(tr.testbase, oc)
-        return tr.result not in (0, 77)
+        return tr.result not in (Exit.PASS, Exit.SKIP, Exit.XFAIL)
 
     if args.parallel > 1:
         # Parallel execution
@@ -624,6 +639,8 @@ def main():
     print(f'      {passed} passed')
     if failed > 0:
         print(f'      {failed} failed')
+    if xfailed > 0:
+        print(f'      {xfailed} xfailed (expected)')
     if skipped > 0:
         print(f'      {skipped} skipped')
     if vg_errors > 0:

--- a/sender.c
+++ b/sender.c
@@ -362,6 +362,7 @@ void send_files(int f_in, int f_out)
 			 * Reconstruct the full path relative to module_dir
 			 * from F_PATHNAME (path) and f_name (fname). */
 			char secure_path[MAXPATHLEN];
+			const char *relp;
 			int slen = snprintf(secure_path, sizeof secure_path, "%s%s%s", path, slash, fname);
 			if (slen >= (int)sizeof secure_path) {
 				io_error |= IOERR_GENERAL;
@@ -371,7 +372,13 @@ void send_files(int f_in, int f_out)
 					send_msg_int(MSG_NO_SEND, ndx);
 				continue;
 			}
-			fd = secure_relative_open(module_dir, secure_path, O_RDONLY, 0);
+			/* A module with `path = /` makes F_PATHNAME absolute, so the
+			 * joined path starts with '/'; strip leading slashes to a
+			 * module-relative path that secure_relative_open accepts (#897). */
+			relp = secure_path;
+			while (*relp == '/')
+				relp++;
+			fd = secure_relative_open(module_dir, relp, O_RDONLY, 0);
 		} else {
 			fd = do_open_checklinks(fname);
 		}

--- a/syscall.c
+++ b/syscall.c
@@ -1780,13 +1780,68 @@ static int secure_relative_open_resolve_beneath(const char *basedir, const char 
 }
 #endif
 
+/* The logical current directory (maintained by change_dir() in util1.c).
+ * Defined here -- rather than in util1.c -- so the test helpers that link
+ * syscall.o but not util1.o (tls, trimslash) get the definition without a
+ * weak-symbol fallback, which is not portable to PE/COFF targets (Cygwin). */
+char curr_dir[MAXPATHLEN];
+unsigned int curr_dir_len;
+
 int secure_relative_open(const char *basedir, const char *relpath, int flags, mode_t mode)
 {
+	extern int am_daemon, am_chrooted;
+	extern char *module_dir;
+	extern unsigned int module_dirlen;
+	char modrel_buf[MAXPATHLEN];
+	int reanchored = 0;
+
 	if (!relpath || relpath[0] == '/') {
 		// must be a relative path
 		errno = EINVAL;
 		return -1;
 	}
+
+	/* Sanitizing daemon only (am_daemon && !am_chrooted).  Here we have chdir'd
+	 * into a sub-dir of the module (the transfer destination), so a relative
+	 * alt-dest like "../01" may legitimately climb to a sibling that is still
+	 * inside the module (#915).  Confining beneath the cwd would reject that
+	 * climb.  Re-anchor at the module root -- the real trust boundary -- by
+	 * prefixing the cwd's module-relative path (from rsync's logical curr_dir[],
+	 * a guaranteed lexical prefix of module_dir, unlike getcwd()) and resolving
+	 * beneath module_dir; RESOLVE_BENEATH then allows in-module climbs and still
+	 * rejects escapes.  Only for paths that contain "..".  module_dirlen is 0 for
+	 * a `path = /` module (clientserver.c), so we gate on module_dir, not its
+	 * length, to cover that case too -- the prefix check below treats
+	 * module_dirlen 0 as "module root is /". */
+	if (am_daemon && !am_chrooted
+	 && module_dir && module_dir[0] == '/'
+	 && (basedir == NULL || basedir[0] != '/')
+	 && (path_has_dotdot_component(relpath)
+	  || (basedir && path_has_dotdot_component(basedir)))) {
+		const char *p;
+		int n;
+		if (curr_dir_len >= module_dirlen
+		 && strncmp(curr_dir, module_dir, module_dirlen) == 0
+		 && (curr_dir[module_dirlen] == '\0' || curr_dir[module_dirlen] == '/')) {
+			for (p = curr_dir + module_dirlen; *p == '/'; p++) {}
+			if (basedir)
+				n = snprintf(modrel_buf, sizeof modrel_buf, "%s%s%s/%s",
+					     p, *p ? "/" : "", basedir, relpath);
+			else
+				n = snprintf(modrel_buf, sizeof modrel_buf, "%s%s%s",
+					     p, *p ? "/" : "", relpath);
+			if (n < 0 || n >= (int)sizeof modrel_buf) {
+				errno = ENAMETOOLONG;
+				return -1;
+			}
+			basedir = module_dir;	/* absolute, operator-trusted anchor */
+			relpath = modrel_buf;
+			reanchored = 1;
+		}
+		/* else: cwd not under module root as expected -- fall through to the
+		 * front-door rejection below (fail safe). */
+	}
+
 	/* Reject any path with a literal ".." component (bare "..",
 	 * "../foo", "foo/..", "foo/../bar", "subdir/.."). The previous
 	 * substring-based check caught only "../" prefix and "/../"
@@ -1795,14 +1850,19 @@ int secure_relative_open(const char *basedir, const char *relpath, int flags, mo
 	 * and pre-5.6 Linux. RESOLVE_BENEATH on Linux/FreeBSD/macOS
 	 * catches some of these in-kernel with EXDEV, but the front
 	 * door must reject them consistently with EINVAL across all
-	 * platforms so callers can rely on the validation. */
-	if (path_has_dotdot_component(relpath)) {
-		errno = EINVAL;
-		return -1;
-	}
-	if (basedir && basedir[0] != '/' && path_has_dotdot_component(basedir)) {
-		errno = EINVAL;
-		return -1;
+	 * platforms so callers can rely on the validation.  Skipped for a
+	 * re-anchored path: its ".." is deliberate, stays within the module,
+	 * and is adjudicated by RESOLVE_BENEATH below (the portable fallback
+	 * re-rejects it -- see there). */
+	if (!reanchored) {
+		if (path_has_dotdot_component(relpath)) {
+			errno = EINVAL;
+			return -1;
+		}
+		if (basedir && basedir[0] != '/' && path_has_dotdot_component(basedir)) {
+			errno = EINVAL;
+			return -1;
+		}
 	}
 
 #if defined(__linux__) && defined(HAVE_OPENAT2)
@@ -1820,6 +1880,21 @@ int secure_relative_open(const char *basedir, const char *relpath, int flags, mo
 #ifdef O_RESOLVE_BENEATH
 	return secure_relative_open_resolve_beneath(basedir, relpath, flags, mode);
 #endif
+
+	/* Portable fallback only (no kernel RESOLVE_BENEATH): the per-component
+	 * O_NOFOLLOW walk below can't adjudicate ".." safely, so reject it here --
+	 * even for a re-anchored path.  This re-breaks --link-dest=../01 on
+	 * openat2/O_RESOLVE_BENEATH-less platforms (NetBSD/OpenBSD/Solaris/Cygwin/
+	 * pre-5.6 Linux), trading function for safety; on the kernel paths above
+	 * RESOLVE_BENEATH already allowed the in-module climb. */
+	if (path_has_dotdot_component(relpath)) {
+		errno = EINVAL;
+		return -1;
+	}
+	if (basedir && basedir[0] != '/' && path_has_dotdot_component(basedir)) {
+		errno = EINVAL;
+		return -1;
+	}
 
 #if !defined(O_NOFOLLOW) || !defined(O_DIRECTORY) || !defined(AT_FDCWD)
 	// really old system, all we can do is live with the risks

--- a/t_stub.c
+++ b/t_stub.c
@@ -45,6 +45,8 @@ size_t max_alloc = (size_t)-1; /* test helpers are not memory-constrained;
 				* hits at its first my_strdup() call. */
 char *partial_dir;
 char *module_dir;
+/* curr_dir[]/curr_dir_len (read by secure_relative_open) are defined in
+ * syscall.c, which every helper links -- no stub needed here. */
 filter_rule_list daemon_filter_list;
 
  void rprintf(UNUSED(enum logcode code), const char *format, ...)

--- a/testsuite/daemon-path-root-read_test.py
+++ b/testsuite/daemon-path-root-read_test.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+# Functional regression: a daemon module with `path = /` (use chroot = no)
+# cannot send ANY file in 3.4.3 -- every read fails with "Invalid argument (22)".
+#
+# Reported as #897 ("Regression in 3.4.3, Invalid argument (22) on all file
+# reads when using native protocol").  Works in 3.4.2, works over a remote
+# shell; only the native (daemon) protocol with an absolute module path breaks.
+#
+# Root cause: the 3.4.3 symlink-race hardening routes the sender's file open
+# through secure_relative_open(module_dir, secure_path, ...) (sender.c), where
+#   secure_path = F_PATHNAME + "/" + f_name.
+# With `path = /` the module-relative F_PATHNAME is itself ABSOLUTE, so
+# secure_path starts with '/'.  secure_relative_open()'s front door rejects any
+# absolute relpath with EINVAL *before* it ever calls openat2 (matching the
+# reporter's strace: the file is stat'd and access()'d but never opened).  The
+# generator then reports "send_files failed to open ...: Invalid argument (22)"
+# and the whole transfer ends in code 23.
+#
+# This is a pure functional regression (no attacker, no symlink): XFAIL until
+# the sender open is made to tolerate an absolute module-root path (the
+# accompanying sender.c fix).  Runs at any uid.
+
+import subprocess
+
+from rsyncfns import (
+    SCRATCHDIR, makepath, rmtree, rsync_argv, start_test_daemon, test_fail,
+    write_daemon_conf,
+)
+
+DAEMON_PORT = 12897
+
+# A small source tree under the scratch dir: a file at the served-subdir root
+# and one nested deeper (the bug fails on EVERY file, regardless of depth).
+served = SCRATCHDIR / 'served'
+dst = SCRATCHDIR / 'pulldst'
+rmtree(served)
+rmtree(dst)
+makepath(served / 'sub')
+makepath(dst)
+(served / 'README').write_text("readme-contents\n")
+(served / 'sub' / 'deep.txt').write_text("deep-contents\n")
+
+# Module rooted at the filesystem root, exactly like the report (path = /,
+# use chroot = no).  We then request the served subtree by its absolute path
+# with the leading '/' stripped, so the daemon serves $served from "/".
+conf = write_daemon_conf([
+    ('root', {'path': '/', 'read only': 'yes'}),
+])
+url = start_test_daemon(conf, DAEMON_PORT)
+
+served_rel = str(served).lstrip('/')          # e.g. tmp/.../served
+proc = subprocess.run(
+    rsync_argv('-a', f'{url}root/{served_rel}/', f'{dst}/'),
+    stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True,
+)
+out = proc.stdout or ''
+print(out)
+
+# Bug present: the sender refuses to open the files with EINVAL(22).
+if 'Invalid argument (22)' in out or ('failed to open' in out and proc.returncode != 0):
+    from rsyncfns import test_xfail
+    test_xfail(
+        "#897: daemon module `path = /` (use chroot = no) cannot send files -- "
+        "`send_files failed to open ...: Invalid argument (22)`.  The sender's "
+        "secure_relative_open(module_dir, secure_path) gets an ABSOLUTE "
+        "secure_path (F_PATHNAME is absolute when path=/) and the front door "
+        "rejects absolute relpaths with EINVAL before any openat2.  To be closed "
+        "by letting the sender open succeed for an absolute module-root path.")
+
+# Bug fixed (or never present): the files transfer intact.
+if proc.returncode != 0:
+    test_fail(f"daemon pull failed unexpectedly (rc={proc.returncode}); "
+              f"not the #897 EINVAL symptom:\n{out}")
+for rel in ('README', 'sub/deep.txt'):
+    got = dst / rel
+    if not got.is_file():
+        test_fail(f"daemon pull did not deliver {rel} (dst={dst})")
+    if got.read_text() != (served / rel).read_text():
+        test_fail(f"delivered {rel} content differs from source")

--- a/testsuite/delete-missing-args-files-from_test.py
+++ b/testsuite/delete-missing-args-files-from_test.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+# Functional regression: --delete-missing-args with --files-from aborts the
+# transfer with "invalid file mode 00 ... protocol incompatibility (code 2)"
+# instead of deleting the entries that are missing on the sender.
+#
+# Reported as #910 ("Security fix in flist.c breaks --delete-missing-args with
+# --files-from").
+#
+# Root cause: for a --files-from entry that does not exist on the sender,
+# --delete-missing-args==2 deliberately sends a "missing" file entry with
+# mode == 0 (the generator's signal to delete it on the receiver).  The 3.4.x
+# security mode-validation added to recv_file_entry() (flist.c) rejects mode 0
+# as an invalid file type BEFORE the generator can act on it, so the receiver
+# bails out with a protocol error and nothing is deleted.  Works in 3.4.1.
+#
+# Two scenarios, since a missing FILE and a missing DIRECTORY are sent as
+# distinct mode-0 entries:
+#   * a regular file present on the receiver but absent on the sender, and
+#   * a directory present on the receiver but absent on the sender,
+# both named in --files-from.  Both must be deleted on the receiver.
+#
+# XFAIL until recv_file_entry() accepts the missing-args mode-0 entry again
+# (the accompanying flist.c fix).  Runs at any uid.
+
+import subprocess
+
+from rsyncfns import (
+    SCRATCHDIR, makepath, rmtree, rsync_argv, start_test_daemon, test_fail,
+    test_xfail, write_daemon_conf,
+)
+
+DAEMON_PORT = 12910
+
+mod = SCRATCHDIR / 'recvmod910'    # daemon receive module
+src = SCRATCHDIR / 'src910'
+rmtree(mod)
+rmtree(src)
+makepath(mod / 'ghostdir', src)
+(src / 'keep.txt').write_text("keep-me\n")            # present on sender
+(mod / 'keep.txt').write_text("stale\n")              # will be updated
+(mod / 'ghost.txt').write_text("delete-me-file\n")    # absent on sender -> delete
+(mod / 'ghostdir' / 'inner').write_text("delete-me-dir\n")  # absent on sender -> delete
+
+# --files-from lists one present file plus the two entries that are missing on
+# the sender (a file and a directory) -- those become mode-0 "missing" entries.
+flist = SCRATCHDIR / 'files910.lst'
+flist.write_text("keep.txt\nghost.txt\nghostdir\n")
+
+conf = write_daemon_conf([
+    ('recv', {'path': str(mod), 'read only': 'no'}),
+])
+url = start_test_daemon(conf, DAEMON_PORT)
+
+proc = subprocess.run(
+    rsync_argv('-a', '--delete', '--delete-missing-args',
+               f'--files-from={flist}', f'{src}/', f'{url}recv/'),
+    stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True)
+out = proc.stdout or ''
+print(out)
+
+# Bug present: the receiver rejects the mode-0 missing-args entry.
+if 'invalid file mode' in out or (proc.returncode == 2 and (mod / 'ghost.txt').exists()):
+    test_xfail(
+        "#910: --delete-missing-args with --files-from aborts with "
+        "`invalid file mode 00 ... protocol incompatibility (code 2)`.  The "
+        "sender sends mode-0 entries for the missing args (the delete signal), "
+        "but recv_file_entry()'s 3.4.x mode-validation rejects mode 0 before the "
+        "generator can delete them.  To be closed by accepting the "
+        "missing-args mode-0 entry in recv_file_entry().")
+
+# Bug fixed (or absent): both missing args were deleted, the present file kept.
+if proc.returncode != 0:
+    test_fail(f"transfer failed unexpectedly (rc={proc.returncode}); "
+              f"not the #910 mode-00 symptom:\n{out}")
+if (mod / 'ghost.txt').exists():
+    test_fail("missing-arg file ghost.txt was not deleted on the receiver")
+if (mod / 'ghostdir').exists():
+    test_fail("missing-arg directory ghostdir was not deleted on the receiver")
+if not (mod / 'keep.txt').is_file() or (mod / 'keep.txt').read_text() != "keep-me\n":
+    test_fail("present file keep.txt was not delivered/updated correctly")

--- a/testsuite/exitcodes.py
+++ b/testsuite/exitcodes.py
@@ -1,0 +1,17 @@
+"""Exit codes a test reports to runtests.py (autotools test convention).
+
+Shared by runtests.py (the harness, which reads these from each test) and
+rsyncfns.py (the helpers, which exit with them) so the 0/1/2/77/78 values are
+named in exactly one place.  This module has no import-time side effects, so
+runtests.py can import it without pulling in rsyncfns's environment checks.
+"""
+
+import enum
+
+
+class Exit(enum.IntEnum):
+    PASS = 0
+    FAIL = 1
+    ERROR = 2     # the test could not run (e.g. missing environment)
+    SKIP = 77
+    XFAIL = 78    # expected failure: a known, documented residual

--- a/testsuite/link-dest-module-escape_test.py
+++ b/testsuite/link-dest-module-escape_test.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+# Security guard for the #915 re-anchor: a daemon receiver must NOT honour an
+# alt-basis dir whose `..` climbs OUT of the module.
+#
+# Honouring a relative --link-dest=../01 again (#915) deliberately re-permits an
+# in-module `..` climb (dest 00 -> sibling basis 01).  This test pins the other
+# side of that boundary: a client-supplied --link-dest=../../OUTSIDE that points
+# at a file OUTSIDE the module root must be refused, so the basis is never used
+# and the dest file is re-transferred rather than hard-linked to the outside
+# file (which would be an info-leak / cross-module hard-link).
+#
+# The re-anchor confines resolution beneath module_dir with RESOLVE_BENEATH, so
+# the escaping climb is rejected in-kernel; on platforms without
+# openat2/O_RESOLVE_BENEATH the portable resolver rejects the `..` outright.
+# Either way the escape is blocked, so this test must PASS on every platform.
+# Runs at any uid.
+
+import shutil
+import subprocess
+
+from rsyncfns import (
+    SCRATCHDIR, make_data_file, makepath, rmtree, rsync_argv, start_test_daemon,
+    test_fail, write_daemon_conf,
+)
+
+DAEMON_PORT = 12916
+DATA_SIZE = 40000
+
+mod = SCRATCHDIR / 'escmod'          # daemon module root (holds dest 00)
+src = SCRATCHDIR / 'escsrc'
+outside = SCRATCHDIR / 'OUTSIDE'     # sibling of the module root -- OUTSIDE it
+for d in (mod, src, outside):
+    rmtree(d)
+makepath(mod / '00', src, outside)
+
+# Source file, plus a byte-identical secret OUTSIDE the module with the same
+# name/size/mtime (so a followed basis would quick-check as a match).
+make_data_file(src / 'f.dat', DATA_SIZE)
+shutil.copy2(src / 'f.dat', outside / 'f.dat')
+
+conf = write_daemon_conf([
+    ('bak', {'path': str(mod), 'read only': 'no'}),
+])
+url = start_test_daemon(conf, DAEMON_PORT)
+
+# Dest is bak/00 (cwd = module/00).  --link-dest=../../OUTSIDE climbs
+# module/00 -> module -> SCRATCHDIR/OUTSIDE, i.e. out of the module.
+proc = subprocess.run(
+    rsync_argv('-a', '--link-dest=../../OUTSIDE', f'{src}/', f'{url}bak/00/'),
+    stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True)
+out = proc.stdout or ''
+if proc.returncode not in (0, 23):    # 23: a basis rejection is non-fatal here
+    test_fail(f"escape push failed unexpectedly (rc={proc.returncode}):\n{out}")
+
+dest = mod / '00' / 'f.dat'
+secret = outside / 'f.dat'
+if not dest.is_file():
+    test_fail(f"destination file missing ({dest})")
+
+ds, ss = dest.stat(), secret.stat()
+if (ds.st_dev, ds.st_ino) == (ss.st_dev, ss.st_ino):
+    test_fail(
+        "MODULE ESCAPE: the dest was hard-linked to a file OUTSIDE the module "
+        f"via --link-dest=../../OUTSIDE -- the confined resolver let a `..` "
+        f"climb escape the module root.\n{out}")
+# Escape blocked: the basis was refused, so the file was re-transferred and the
+# dest is its own inode, not the outside secret's.

--- a/testsuite/link-dest-pathroot_test.py
+++ b/testsuite/link-dest-pathroot_test.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+# Functional regression: a relative --link-dest=../sibling against a daemon
+# module with `path = /` (the intersection of #897 and #915).
+#
+# #915 re-anchors the receiver's basis open at the module root so an in-module
+# "../01" climb is honoured.  The gate keyed on a nonzero module_dirlen, but a
+# `path = /` module has module_dirlen == 0 (clientserver.c), so the re-anchor
+# was skipped there and --link-dest=../01 was silently ignored (every file
+# re-transferred) even though plain #915 modules were fixed.
+#
+# Like link-dest-relative-basis this XFAILs on platforms without
+# openat2/O_RESOLVE_BENEATH (the portable resolver rejects the '..' for safety);
+# it flips to PASS where the kernel can adjudicate the in-module climb.  Runs at
+# any uid.
+
+import shutil
+import subprocess
+
+from rsyncfns import (
+    SCRATCHDIR, make_data_file, makepath, rmtree, rsync_argv, start_test_daemon,
+    test_fail, test_xfail, write_daemon_conf,
+)
+
+DAEMON_PORT = 12931
+DATA_SIZE = 40000
+
+# dest 00 and basis 01 live side by side under `base`; the module is rooted at
+# "/", so the served subtree is addressed by its absolute path minus the leading
+# slash, and --link-dest=../01 climbs dest 00 -> sibling 01 (both inside /).
+base = SCRATCHDIR / 'bakroot'
+src = SCRATCHDIR / 'srcroot'
+rmtree(base)
+rmtree(src)
+makepath(base / '01', src)
+make_data_file(src / 'f.dat', DATA_SIZE)
+shutil.copy2(src / 'f.dat', base / '01' / 'f.dat')
+
+conf = write_daemon_conf([
+    ('root', {'path': '/', 'read only': 'no'}),
+])
+url = start_test_daemon(conf, DAEMON_PORT)
+
+base_rel = str(base).lstrip('/')          # address `base` via the path=/ module
+rmtree(base / '00')
+proc = subprocess.run(
+    rsync_argv('-a', '--link-dest=../01', f'{src}/', f'{url}root/{base_rel}/00/'),
+    stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True)
+out = proc.stdout or ''
+if proc.returncode not in (0, 23):    # 23: no-RESOLVE_BENEATH platforms reject the basis
+    test_fail(f"path=/ --link-dest push failed unexpectedly (rc={proc.returncode}):\n{out}")
+
+dest = base / '00' / 'f.dat'
+basis = base / '01' / 'f.dat'
+if not dest.is_file():
+    test_fail(f"destination file missing ({dest})")
+
+ds, bs = dest.stat(), basis.stat()
+if (ds.st_dev, ds.st_ino) != (bs.st_dev, bs.st_ino):
+    test_xfail(
+        "#915 (path=/ case): a `path = /` daemon module ignored --link-dest=../01 "
+        "(module_dirlen==0 skipped the re-anchor) -- the file was re-transferred "
+        "instead of hard-linked.  Honoured once the re-anchor covers path=/.")
+# Honoured: the dest is hard-linked to the in-module sibling basis.

--- a/testsuite/link-dest-relative-basis_test.py
+++ b/testsuite/link-dest-relative-basis_test.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+# Functional regression: a RELATIVE alt-basis dir (--link-dest / --copy-dest /
+# --compare-dest = ../sibling) is silently ignored by a daemon receiver, so the
+# basis is never used -- every file is re-transferred instead of hard-linked /
+# copied / skipped.  No error is printed; backups silently stop de-duplicating.
+#
+# Reported as #915 ("Security fix breaks --link-dest via rsync daemon": a
+# `use chroot = no` daemon with `--link-dest=../01` re-transfers everything and
+# fills the backup disk).  The closely-related #928 is the same family over a
+# remote shell with a relative `--link-dest=../snap.1`.
+#
+# Root cause: the 3.4.x symlink-race hardening resolves the receiver's basis
+# through the confined resolver, which rejects the `..` that climbs from the
+# destination (00) to its sibling basis (01); no basis is found, so the file is
+# treated as new.  Works in 3.4.1 (basis honoured).
+#
+# We exercise all three alt-basis forms because they are NOT obviously identical
+# even though they share check_alt_basis_dirs():
+#   * --link-dest=../01   : the matched file must be HARD-LINKED to the basis.
+#   * --copy-dest=../01   : the matched file is COPIED from the basis, so its
+#                           data is NOT sent over the wire (literal data ~ 0).
+#   * --compare-dest=../01 : a matched file is skipped entirely -- NOT created
+#                           in the destination at all.
+# Each signal cleanly separates "basis honoured" (fixed/3.4.1) from "basis
+# ignored" (the regression).
+#
+# XFAIL until a relative alt-basis dir is honoured by a sanitize_paths receiver
+# again (the accompanying syscall.c/receiver.c fix; cf. upstream PR #930).  On
+# platforms without openat2/O_RESOLVE_BENEATH the portable resolver still
+# rejects the '..' for safety, so this stays XFAIL there.  Runs at any uid.
+
+import re
+import subprocess
+
+from rsyncfns import (
+    SCRATCHDIR, make_data_file, makepath, rmtree, rsync_argv, start_test_daemon,
+    test_fail, test_xfail, write_daemon_conf,
+)
+
+DAEMON_PORT = 12915
+DATA_SIZE = 40000
+
+mod = SCRATCHDIR / 'bakmod'        # daemon module root: holds basis 01 and dest 00
+src = SCRATCHDIR / 'src915'
+rmtree(mod)
+rmtree(src)
+makepath(mod / '01', src)
+make_data_file(src / 'f.dat', DATA_SIZE)
+# Basis 01 holds a byte-identical copy of the file (same name/size/mtime so the
+# quick-check treats it as a match and the basis is eligible).
+import shutil
+shutil.copy2(src / 'f.dat', mod / '01' / 'f.dat')
+
+conf = write_daemon_conf([
+    ('bak', {'path': str(mod), 'read only': 'no'}),
+])
+url = start_test_daemon(conf, DAEMON_PORT)
+
+
+def push(opt):
+    """Fresh dest 00, push src/ into bak/00/ with the given alt-basis option.
+    Returns (rc, stdout)."""
+    rmtree(mod / '00')
+    proc = subprocess.run(
+        rsync_argv('-a', '--stats', opt, f'{src}/', f'{url}bak/00/'),
+        stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True)
+    return proc.returncode, (proc.stdout or '')
+
+
+def same_inode(a, b):
+    sa, sb = a.stat(), b.stat()
+    return (sa.st_dev, sa.st_ino) == (sb.st_dev, sb.st_ino)
+
+
+def literal_bytes(out):
+    m = re.search(r'Literal data:\s*([\d,]+)', out)
+    return int(m.group(1).replace(',', '')) if m else -1
+
+
+regressions = []
+basis = mod / '01' / 'f.dat'
+
+# --- 1. --link-dest=../01 : matched file must be hard-linked to the basis ----
+rc, out = push('--link-dest=../01')
+if rc not in (0, 23):    # 23: no-RESOLVE_BENEATH platforms reject the basis
+    test_fail(f"--link-dest push failed unexpectedly (rc={rc}):\n{out}")
+dest = mod / '00' / 'f.dat'
+if not dest.is_file():
+    test_fail(f"--link-dest: destination file missing ({dest})")
+if not same_inode(dest, basis):
+    regressions.append("--link-dest=../01 did not hard-link to the basis "
+                       "(file re-transferred)")
+
+# --- 2. --copy-dest=../01 : matched file copied locally, NOT sent on the wire -
+rc, out = push('--copy-dest=../01')
+if rc not in (0, 23):    # 23: no-RESOLVE_BENEATH platforms reject the basis
+    test_fail(f"--copy-dest push failed unexpectedly (rc={rc}):\n{out}")
+dest = mod / '00' / 'f.dat'
+if not dest.is_file():
+    test_fail(f"--copy-dest: destination file missing ({dest})")
+lit = literal_bytes(out)
+if lit > DATA_SIZE // 2:
+    regressions.append(f"--copy-dest=../01 re-sent the data over the wire "
+                       f"(Literal data={lit}, basis not used)")
+
+# --- 3. --compare-dest=../01 : matched file skipped, NOT created in dest ------
+rc, out = push('--compare-dest=../01')
+if rc not in (0, 23):    # 23: no-RESOLVE_BENEATH platforms reject the basis
+    test_fail(f"--compare-dest push failed unexpectedly (rc={rc}):\n{out}")
+if (mod / '00' / 'f.dat').is_file():
+    regressions.append("--compare-dest=../01 created the file in the dest "
+                       "(basis not matched, so the file was transferred)")
+
+if regressions:
+    test_xfail(
+        "#915: a daemon receiver ignored a RELATIVE alt-basis dir (../01); the "
+        "confined path resolver rejects the `..` climb to the sibling basis so "
+        "the basis is never used:\n  - " + "\n  - ".join(regressions) +
+        "\nTo be closed by honouring a relative alt-basis dir on a "
+        "sanitize_paths receiver again (cf. PR #930).")
+# No regressions -> all three relative alt-basis forms honoured the basis.

--- a/testsuite/rsyncfns.py
+++ b/testsuite/rsyncfns.py
@@ -5,7 +5,7 @@ the Python-rewritten tests actually need; grow it as more shell tests are
 ported.
 
 Conventions matching the shell harness:
-  * Exit 0 = pass, 1 = fail, 77 = skip, 78 = xfail.
+  * Exit codes (see the Exit enum): 0=pass, 1=fail, 2=error, 77=skip, 78=xfail.
   * The runner sets these environment variables before invoking each test:
       scratchdir   per-test scratch directory
       srcdir       rsync source directory
@@ -31,6 +31,8 @@ import sys
 import time
 from pathlib import Path
 
+from exitcodes import Exit   # re-exported: tests may `from rsyncfns import Exit`
+
 
 # --- environment -----------------------------------------------------------
 
@@ -41,7 +43,7 @@ def _required(name: str) -> str:
             f"rsyncfns: required environment variable {name} is not set; "
             "run this test via runtests.py rather than directly.\n"
         )
-        sys.exit(2)
+        sys.exit(Exit.ERROR)
     return v
 
 
@@ -105,18 +107,18 @@ OUTFILE = SCRATCHDIR / 'rsync.out'
 
 def test_fail(msg: str) -> 'None':
     sys.stderr.write(msg.rstrip() + '\n')
-    sys.exit(1)
+    sys.exit(Exit.FAIL)
 
 
 def test_skipped(msg: str) -> 'None':
     sys.stderr.write(msg.rstrip() + '\n')
     (TMPDIR / 'whyskipped').write_text(msg.rstrip() + '\n')
-    sys.exit(77)
+    sys.exit(Exit.SKIP)
 
 
 def test_xfail(msg: str) -> 'None':
     sys.stderr.write(msg.rstrip() + '\n')
-    sys.exit(78)
+    sys.exit(Exit.XFAIL)
 
 
 # --- rsync invocation ------------------------------------------------------

--- a/util1.c
+++ b/util1.c
@@ -41,8 +41,8 @@ extern filter_rule_list daemon_filter_list;
 
 int sanitize_paths = 0;
 
-char curr_dir[MAXPATHLEN];
-unsigned int curr_dir_len;
+extern char curr_dir[MAXPATHLEN];   /* defined in syscall.c */
+extern unsigned int curr_dir_len;
 int curr_dir_depth; /* This is only set for a sanitizing daemon. */
 
 /* Set a fd into nonblocking mode. */


### PR DESCRIPTION
This fixes some of the reported regressions from recent releases. Each was an edge case not caught either by the test suite at the time of the release or by manual testing. The curse of security releases is you can't do a beta release to the community. Apologies for the regressions!

Fixes issues
 - #910 
 - #897 
 - #915 
 - #928

also PR #930 