### PR TITLE
fix: install generated manpages out of tree

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -84,12 +84,19 @@ install: all
 	$(INSTALLCMD) -m 755 $(srcdir)/rsync-ssl $(DESTDIR)$(bindir)
 	-$(MKDIR_P) $(DESTDIR)$(mandir)/man1
 	-$(MKDIR_P) $(DESTDIR)$(mandir)/man5
-	if test -f rsync.1; then $(INSTALLMAN) -m 644 rsync.1 $(DESTDIR)$(mandir)/man1; fi
-	if test -f rsync-ssl.1; then $(INSTALLMAN) -m 644 rsync-ssl.1 $(DESTDIR)$(mandir)/man1; fi
-	if test -f rsyncd.conf.5; then $(INSTALLMAN) -m 644 rsyncd.conf.5 $(DESTDIR)$(mandir)/man5; fi
+	for fn in rsync.1 rsync-ssl.1; do \
+	    if test -f $$fn; then $(INSTALLMAN) -m 644 $$fn $(DESTDIR)$(mandir)/man1; \
+	    elif test -f $(srcdir)/$$fn; then $(INSTALLMAN) -m 644 $(srcdir)/$$fn $(DESTDIR)$(mandir)/man1; fi; \
+	done
+	for fn in rsyncd.conf.5; do \
+	    if test -f $$fn; then $(INSTALLMAN) -m 644 $$fn $(DESTDIR)$(mandir)/man5; \
+	    elif test -f $(srcdir)/$$fn; then $(INSTALLMAN) -m 644 $(srcdir)/$$fn $(DESTDIR)$(mandir)/man5; fi; \
+	done
 	if test "$(with_rrsync)" = yes; then \
 	    $(INSTALLCMD) -m 755 rrsync $(DESTDIR)$(bindir); \
-	    if test -f rrsync.1; then $(INSTALLMAN) -m 644 rrsync.1 $(DESTDIR)$(mandir)/man1; fi; \
+	    fn=rrsync.1; \
+	    if test -f $$fn; then $(INSTALLMAN) -m 644 $$fn $(DESTDIR)$(mandir)/man1; \
+	    elif test -f $(srcdir)/$$fn; then $(INSTALLMAN) -m 644 $(srcdir)/$$fn $(DESTDIR)$(mandir)/man1; fi; \
 	fi
 
 install-ssl-daemon: stunnel-rsyncd.conf


### PR DESCRIPTION
Fixes #846 by installing generated manpages from the source directory when they are not present in an out-of-tree build directory.

Release tarballs include pre-generated manpages. With an out-of-tree build configured using `--disable-md2man`, `make install` could install the binaries but skip the manpages because the install rule only checked the build directory.

This keeps the existing build-directory preference then falls back to `$(srcdir)` for `rsync.1`, `rsync-ssl.1`, `rsyncd.conf.5` and the optional `rrsync.1`.

Tested with a v3.4.3 release tarball using:
- `../configure --disable-md2man --with-rrsync`
- `make`
- `make install DESTDIR=...`

Before this change, the install tree missed the generated manpages. After this change, `rsync.1`, `rsync-ssl.1`, `rrsync.1` and `rsyncd.conf.5` are installed.