### PR TITLE
build: fix rrsync manpage fallback

### DIFF
--- a/maybe-make-man
+++ b/maybe-make-man
@@ -15,7 +15,7 @@ if [ ! -f "$flagfile" ]; then
     if "$srcdir/md-convert" --test "$srcdir/rsync-ssl.1.md" >/dev/null 2>&1; then
 	touch $flagfile
     else
-	outname=`echo "$inname" | sed 's/\.md$//'`
+	outname=`basename "$inname" .md`
 	if [ -f "$outname" ]; then
 	    exit 0
 	elif [ -f "$srcdir/$outname" ]; then


### PR DESCRIPTION
Fixes #868 by making `maybe-make-man` derive fallback manpage names from the output basename rather than the markdown input path.

When `--with-rrsync` is enabled and md2man cannot generate manpages, `make man` calls `maybe-make-man support/rrsync.1.md`. The generated and release manpage name is `rrsync.1` but the fallback path previously looked for `support/rrsync.1`. That missed the prebuilt release manpage and failed with `ERROR: support/rrsync.1 cannot be created.` This keeps the existing fallback behaviour for top-level manpages and makes the support/rrsync path match the actual generated output name.