### PR TITLE
docs: mention systemd rsync daemon units

### DIFF
--- a/rsyncd.conf.5.md
+++ b/rsyncd.conf.5.md
@@ -56,6 +56,13 @@ You can launch it either via inetd, as a stand-alone daemon, or from an rsync
 client via a remote shell.  If run as a stand-alone daemon then just run the
 command "`rsync --daemon`" from a suitable startup script.
 
+Systems using systemd can use the example unit files in the source tree's
+`packaging/systemd` directory.  The `rsync.service` file runs a stand-alone
+daemon using `rsync --daemon --no-detach`, while `rsync.socket` and
+`rsync@.service` show a socket-activated setup for incoming connections.  These
+files may need local adjustment to match your installed rsync path, packaging
+layout, and module policy.
+
 When run via inetd you should add a line like this to /etc/services:
 
 >     rsync           873/tcp


### PR DESCRIPTION
Fixes #833 by documenting the existing systemd unit examples in `packaging/systemd`.

The rsyncd.conf manpage already describes stand-alone daemon startup, inetd startup and remote-shell daemon startup. This adds a short systemd note that points users to the shipped example units and distinguishes the standalone service from the socket-activated setup.