### PR TITLE
configure: avoid runtime IPv6 availability probe

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -432,21 +432,17 @@ AS_HELP_STRING([--disable-ipv6],[disable to omit ipv6 support]),
 	;;
   esac ],
 
-  AC_RUN_IFELSE([AC_LANG_SOURCE([[ /* AF_INET6 availability check */
-#include <stdlib.h>
+  AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
 #include <sys/types.h>
 #include <sys/socket.h>
-int main()
-{
-   if (socket(AF_INET6, SOCK_STREAM, 0) < 0)
-     exit(1);
-   else
-     exit(0);
-}
+#include <netinet/in.h>
+]], [[
+struct sockaddr_in6 sa6;
+(void)sa6;
+(void)AF_INET6;
 ]])],
   [AC_MSG_RESULT(yes)
-  AC_DEFINE(INET6, 1, true if you have IPv6)],
-  [AC_MSG_RESULT(no)],
+  AC_DEFINE(INET6, 1, [true if you have IPv6])],
   [AC_MSG_RESULT(no)]
 ))
 


### PR DESCRIPTION
Fixes #675 by making the default IPv6 configure check depend on compile-time support rather than runtime socket availability.

The previous probe opened an IPv6 socket during configure, so the build result could vary when the build host had IPv6 disabled at runtime. The runtime socket path already handles IPv6 socket failures and falls back where appropriate so configure only needs to know whether the platform exposes IPv6 types and constants.

This keeps `--disable-ipv6` as the explicit opt-out.