### PR TITLE
build: add uninstall targets

### DIFF
--- a/.github/workflows/ubuntu-build.yml
+++ b/.github/workflows/ubuntu-build.yml
@@ -30,6 +30,34 @@ jobs:
       run: ./configure --with-rrsync
     - name: make
       run: make
+    - name: install/uninstall DESTDIR smoke test
+      run: |
+        set -e
+        tmp="$(mktemp -d)"
+        trap 'rm -rf "$tmp"' EXIT
+
+        make install-all DESTDIR="$tmp"
+
+        for path in \
+          /usr/local/bin/rsync \
+          /usr/local/bin/rsync-ssl \
+          /usr/local/bin/rrsync \
+          /usr/local/share/man/man1/rsync.1 \
+          /usr/local/share/man/man1/rsync-ssl.1 \
+          /usr/local/share/man/man1/rrsync.1 \
+          /usr/local/share/man/man5/rsyncd.conf.5 \
+          /etc/stunnel/rsyncd.conf
+        do
+          test -e "$tmp$path"
+        done
+
+        make uninstall-all DESTDIR="$tmp"
+
+        leftover="$(find "$tmp" -type f -print)"
+        if [ -n "$leftover" ]; then
+          printf '%s\n' "$leftover"
+          exit 1
+        fi
     - name: install
       run: sudo make install
     - name: info

--- a/Makefile.in
+++ b/Makefile.in
@@ -111,6 +111,21 @@ install-all: install install-ssl-daemon
 install-strip:
 	$(MAKE) INSTALL_STRIP='-s' install
 
+.PHONY: uninstall
+uninstall:
+	rm -f $(DESTDIR)$(bindir)/rsync$(EXEEXT) $(DESTDIR)$(bindir)/rsync-ssl
+	rm -f $(DESTDIR)$(bindir)/rrsync
+	rm -f $(DESTDIR)$(mandir)/man1/rsync.1 $(DESTDIR)$(mandir)/man1/rsync-ssl.1
+	rm -f $(DESTDIR)$(mandir)/man1/rrsync.1
+	rm -f $(DESTDIR)$(mandir)/man5/rsyncd.conf.5
+
+.PHONY: uninstall-ssl-daemon
+uninstall-ssl-daemon:
+	rm -f $(DESTDIR)/etc/stunnel/rsyncd.conf
+
+.PHONY: uninstall-all
+uninstall-all: uninstall uninstall-ssl-daemon
+
 rsync$(EXEEXT): $(OBJS)
 	$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $(OBJS) $(LIBS)
 

--- a/packaging/auto-Makefile
+++ b/packaging/auto-Makefile
@@ -1,4 +1,4 @@
-TARGETS := all install install-ssl-daemon install-all install-strip conf gen reconfigure restatus \
+TARGETS := all install install-ssl-daemon install-all install-strip uninstall uninstall-ssl-daemon uninstall-all conf gen reconfigure restatus \
 	proto man clean cleantests distclean test check check29 check30 installcheck splint \
 	doxygen doxygen-upload finddead rrsync
 


### PR DESCRIPTION
Fixes #784 by adding uninstall targets that mirror the files installed by the existing install targets.

This adds:
- `make uninstall` for the main binaries and manpages
- `make uninstall-ssl-daemon` for the stunnel daemon config installed by `install-ssl-daemon`
- `make uninstall-all` for both sets

The target removes known installed files with `rm -f` and does not remove install directories or unrelated files.