### PR TITLE
docs: describe files-from comments

### DIFF
--- a/rsync.1.md
+++ b/rsync.1.md
@@ -2390,9 +2390,9 @@ expand it.
 
     The filenames that are read from the FILE are all relative to the source
     dir -- any leading slashes are removed and no ".." references are allowed
-    to go higher than the source dir.  Blank lines are ignored, as are
-    whole-line comments that start with '`;`' or '`#`' (unless [`--from0`](#opt)
-    is specified).  For example, take this command:
+    to go higher than the source dir.  Blank entries are ignored, as are
+    whole-entry comments that start with '`;`' or '`#`'.  For example, take
+    this command:
 
     >     rsync -a --files-from=/tmp/foo /usr remote:/backup
 

--- a/rsync.1.md
+++ b/rsync.1.md
@@ -2390,7 +2390,9 @@ expand it.
 
     The filenames that are read from the FILE are all relative to the source
     dir -- any leading slashes are removed and no ".." references are allowed
-    to go higher than the source dir.  For example, take this command:
+    to go higher than the source dir.  Blank lines are ignored, as are
+    whole-line comments that start with '`;`' or '`#`' (unless [`--from0`](#opt)
+    is specified).  For example, take this command:
 
     >     rsync -a --files-from=/tmp/foo /usr remote:/backup
 

--- a/testsuite/files-from-depth_test.py
+++ b/testsuite/files-from-depth_test.py
@@ -44,8 +44,10 @@ for rel in listed:
 for rel in unlisted:
     assert_not_exists(TODIR / rel, label=f'--from0 excluded {rel}')
 
-# --- comments: line mode ignores them, --from0 treats them as filenames ------
+# --- comments: line mode and --from0 both ignore them -----------------------
 rmtree(TODIR)
+(src / '#ignored').write_text('hash ignored\n')
+(src / ';ignored').write_text('semi ignored\n')
 commented = SCRATCHDIR / 'files-commented.lst'
 commented.write_text('\n'.join(['', ';ignored', '#ignored', *listed]) + '\n')
 run_rsync('-a', f'--files-from={commented}', f'{src}/', f'{TODIR}/')
@@ -53,17 +55,20 @@ for rel in listed:
     assert_same(TODIR / rel, src / rel, label=f'--files-from comment list {rel}')
 for rel in unlisted:
     assert_not_exists(TODIR / rel, label=f'--files-from comment list excluded {rel}')
+for rel in ['#ignored', ';ignored']:
+    assert_not_exists(TODIR / rel, label=f'--files-from comment list skipped {rel}')
 
 rmtree(TODIR)
-(src / '#literal').write_text('hash literal\n')
-(src / ';literal').write_text('semi literal\n')
 comments0 = SCRATCHDIR / 'files-comments0.lst'
-comments0.write_bytes(b'#literal\0;literal\0')
+comments0.write_bytes(
+    b'\0;ignored\0#ignored\0' + b'\0'.join(p.encode() for p in listed) + b'\0')
 run_rsync('-a', '--from0', f'--files-from={comments0}', f'{src}/', f'{TODIR}/')
-assert_same(TODIR / '#literal', src / '#literal',
-            label='--from0 literal hash filename')
-assert_same(TODIR / ';literal', src / ';literal',
-            label='--from0 literal semicolon filename')
+for rel in listed:
+    assert_same(TODIR / rel, src / rel, label=f'--from0 comment list {rel}')
+for rel in unlisted:
+    assert_not_exists(TODIR / rel, label=f'--from0 comment list excluded {rel}')
+for rel in ['#ignored', ';ignored']:
+    assert_not_exists(TODIR / rel, label=f'--from0 comment list skipped {rel}')
 
 # --- --exclude-from drops matching files at depth ---------------------------
 seed()

--- a/testsuite/files-from-depth_test.py
+++ b/testsuite/files-from-depth_test.py
@@ -44,6 +44,27 @@ for rel in listed:
 for rel in unlisted:
     assert_not_exists(TODIR / rel, label=f'--from0 excluded {rel}')
 
+# --- comments: line mode ignores them, --from0 treats them as filenames ------
+rmtree(TODIR)
+commented = SCRATCHDIR / 'files-commented.lst'
+commented.write_text('\n'.join(['', ';ignored', '#ignored', *listed]) + '\n')
+run_rsync('-a', f'--files-from={commented}', f'{src}/', f'{TODIR}/')
+for rel in listed:
+    assert_same(TODIR / rel, src / rel, label=f'--files-from comment list {rel}')
+for rel in unlisted:
+    assert_not_exists(TODIR / rel, label=f'--files-from comment list excluded {rel}')
+
+rmtree(TODIR)
+(src / '#literal').write_text('hash literal\n')
+(src / ';literal').write_text('semi literal\n')
+comments0 = SCRATCHDIR / 'files-comments0.lst'
+comments0.write_bytes(b'#literal\0;literal\0')
+run_rsync('-a', '--from0', f'--files-from={comments0}', f'{src}/', f'{TODIR}/')
+assert_same(TODIR / '#literal', src / '#literal',
+            label='--from0 literal hash filename')
+assert_same(TODIR / ';literal', src / ';literal',
+            label='--from0 literal semicolon filename')
+
 # --- --exclude-from drops matching files at depth ---------------------------
 seed()
 (src / 'a.skip').write_text('s\n')


### PR DESCRIPTION
Fixes #646 by documenting the comment handling for `--files-from`.

The line-based files-from parser ignores blank lines and whole-line comments starting with `;` or `#`. The docs now mention that behaviour and note that it does not apply when `--from0` is used.