### PR TITLE
ci: move the daily scheduled jobs to weekly

### DIFF
--- a/.github/workflows/almalinux-8-build.yml
+++ b/.github/workflows/almalinux-8-build.yml
@@ -18,7 +18,7 @@ on:
       - '.github/workflows/*.yml'
       - '!.github/workflows/almalinux-8-build.yml'
   schedule:
-    - cron: '42 8 * * *'
+    - cron: '42 8 * * 1'
 
 jobs:
   test:

--- a/.github/workflows/android-static-build.yml
+++ b/.github/workflows/android-static-build.yml
@@ -21,7 +21,7 @@ on:
       - '.github/workflows/*.yml'
       - '!.github/workflows/android-static-build.yml'
   schedule:
-    - cron: '42 8 * * *'
+    - cron: '42 8 * * 1'
   workflow_dispatch:
 
 env:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -12,7 +12,7 @@ on:
       - '.github/workflows/*.yml'
       - '!.github/workflows/coverage.yml'
   schedule:
-    - cron: '42 9 * * *'
+    - cron: '42 9 * * 1'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/cygwin-build.yml
+++ b/.github/workflows/cygwin-build.yml
@@ -12,7 +12,7 @@ on:
       - '.github/workflows/*.yml'
       - '!.github/workflows/cygwin-build.yml'
   schedule:
-    - cron: '42 8 * * *'
+    - cron: '42 8 * * 1'
 
 jobs:
   test:

--- a/.github/workflows/freebsd-build.yml
+++ b/.github/workflows/freebsd-build.yml
@@ -12,7 +12,7 @@ on:
       - '.github/workflows/*.yml'
       - '!.github/workflows/freebsd-build.yml'
   schedule:
-    - cron: '42 8 * * *'
+    - cron: '42 8 * * 1'
 
 jobs:
   test:

--- a/.github/workflows/macos-build.yml
+++ b/.github/workflows/macos-build.yml
@@ -12,7 +12,7 @@ on:
       - '.github/workflows/*.yml'
       - '!.github/workflows/macos-build.yml'
   schedule:
-    - cron: '42 8 * * *'
+    - cron: '42 8 * * 1'
 
 jobs:
   test:

--- a/.github/workflows/netbsd-build.yml
+++ b/.github/workflows/netbsd-build.yml
@@ -12,7 +12,7 @@ on:
       - '.github/workflows/*.yml'
       - '!.github/workflows/netbsd-build.yml'
   schedule:
-    - cron: '42 8 * * *'
+    - cron: '42 8 * * 1'
 
 jobs:
   test:

--- a/.github/workflows/openbsd-build.yml
+++ b/.github/workflows/openbsd-build.yml
@@ -12,7 +12,7 @@ on:
       - '.github/workflows/*.yml'
       - '!.github/workflows/openbsd-build.yml'
   schedule:
-    - cron: '42 8 * * *'
+    - cron: '42 8 * * 1'
 
 jobs:
   test:

--- a/.github/workflows/solaris-build.yml
+++ b/.github/workflows/solaris-build.yml
@@ -12,7 +12,7 @@ on:
       - '.github/workflows/*.yml'
       - '!.github/workflows/solaris-build.yml'
   schedule:
-    - cron: '42 8 * * *'
+    - cron: '42 8 * * 1'
 
 jobs:
   test:

--- a/.github/workflows/ubuntu-22.04-build.yml
+++ b/.github/workflows/ubuntu-22.04-build.yml
@@ -16,7 +16,7 @@ on:
       - '.github/workflows/*.yml'
       - '!.github/workflows/ubuntu-22.04-build.yml'
   schedule:
-    - cron: '42 8 * * *'
+    - cron: '42 8 * * 1'
 
 jobs:
   test:

--- a/.github/workflows/ubuntu-build.yml
+++ b/.github/workflows/ubuntu-build.yml
@@ -12,7 +12,7 @@ on:
       - '.github/workflows/*.yml'
       - '!.github/workflows/ubuntu-build.yml'
   schedule:
-    - cron: '42 8 * * *'
+    - cron: '42 8 * * 1'
 
 jobs:
   test:

--- a/.github/workflows/ubuntu-version-mix.yml
+++ b/.github/workflows/ubuntu-version-mix.yml
@@ -33,7 +33,7 @@ on:
       - '.github/workflows/*.yml'
       - '!.github/workflows/ubuntu-version-mix.yml'
   schedule:
-    - cron: '52 8 * * *'
+    - cron: '52 8 * * 1'
 
 jobs:
   version-mix:


### PR DESCRIPTION
Every platform build (the BSD/Solaris/macOS/cygwin/almalinux/ubuntu jobs), coverage, the version-mix job and the android static build ran on a daily cron *in addition to* push and pull_request to master. Since push/PR already cover every code change, the cron only adds drift coverage -- catching breakage from a moving runner image or toolchain that no commit triggers. Those images do not change daily, so a daily run mostly re-tests an unchanged tree.

Move them all to a weekly cron (Mondays, keeping each job's existing time) to keep that drift coverage at roughly a seventh of the Actions spend and log noise. fleettest was already weekly. Per-change CI on push/PR is unchanged, and workflow_dispatch still allows an on-demand run.