### PR TITLE
release.py: accept a git worktree in require_top_of_checkout()

### DIFF
--- a/packaging/release.py
+++ b/packaging/release.py
@@ -104,8 +104,8 @@ def require_samba_host():
 def require_top_of_checkout():
     if not os.path.isfile('packaging/release.py'):
         die("Run this script from the top of your rsync checkout.")
-    if not os.path.isdir('.git'):
-        die("There is no .git dir in the current directory.")
+    if not os.path.exists('.git'):
+        die("There is no .git in the current directory (run from the top of a git checkout or worktree).")
 
 
 def replace_or_die(regex, repl, txt, die_msg):
@@ -636,6 +636,8 @@ If you have a 'samba' remote configured (git.samba.org:/data/git/rsync.git):
 
 Then upload the tarball + .asc to the GitHub release for {v_ver},
 and announce on rsync-announce@, rsync@, and Discord.
+
+NOTE! Also update the PPAs if needed
 """)
 
 


### PR DESCRIPTION
In a git worktree .git is a file (a gitdir pointer), not a directory, so os.path.isdir('.git') wrongly aborted with "no .git dir" when the release was run from a worktree. Use os.path.exists() so it works from both a normal checkout and a linked worktree.