### PR TITLE
testsuite: fix executability test skip on FreeBSD (EFTYPE)

### DIFF
--- a/testsuite/executability_test.py
+++ b/testsuite/executability_test.py
@@ -5,6 +5,7 @@
 # from source to destination (other permission changes ignored), while a
 # normal copy without -E should leave the destination permissions alone.
 
+import errno
 import os
 
 from rsyncfns import FROMDIR, TODIR, check_perms, run_rsync, test_skipped
@@ -15,11 +16,14 @@ FROMDIR.mkdir(parents=True, exist_ok=True)
 (FROMDIR / '2').write_text("#!/bin/sh\necho 'Program Two!'\n")
 
 # Setuid-and-rwx for owner, nothing else. Some platforms reject 1700 for
-# non-root callers (no permission to set sticky); the shell test treats
-# that case as a skip.
+# non-root callers (no permission to set sticky); FreeBSD rejects it with
+# EFTYPE rather than EPERM. Only skip on those; re-raise anything unexpected.
+_STICKY_SKIP_ERRNOS = {errno.EPERM, errno.EACCES, getattr(errno, 'EFTYPE', None)}
 try:
     os.chmod(FROMDIR / '1', 0o1700)
-except PermissionError:
+except OSError as e:
+    if e.errno not in _STICKY_SKIP_ERRNOS:
+        raise
     test_skipped("Can't chmod")
 os.chmod(FROMDIR / '2', 0o600)
 


### PR DESCRIPTION
## Problem

`executability_test.py` tries to `chmod` a file to mode `0o1700` (sticky + rwx). The test expects this to fail on platforms where non-root can't set the sticky bit, and skips if it does. The handler only caught `PermissionError` (EPERM/EACCES).

FreeBSD and OpenBSD return `EFTYPE` (errno 79, "Inappropriate file type or format") instead — they treat the sticky bit on a regular file as an invalid mode for the file type, not a permission issue. The test therefore errored out on FreeBSD 14, FreeBSD 15, and OpenBSD rather than skipping.

## Fix

Catch `OSError` and check `e.errno` against the expected skip set: `EPERM`, `EACCES`, and `EFTYPE` (via `getattr(errno, 'EFTYPE', None)` so it's a no-op on Linux). Re-raise on any other errno so unexpected failures still surface.

## Verification

- FreeBSD 14.4: `executability` now `SKIP (Can't chmod)`, 100 passed / 26 skipped / 0 failed
- FreeBSD 15.0: `executability` now `SKIP (Can't chmod)`, 100 passed / 26 skipped / 0 failed
- OpenBSD 7.9: `executability` now `SKIP (Can't chmod)`, 89 passed / 1 xfailed / 36 skipped / 0 failed
- Ubuntu 20.04 (kernel 5.4): unaffected, 92 passed / 8 skipped / 0 failed (Linux never raises on this chmod)

Ported from rsync-private#25.

🤖 Generated with [Claude Code](https://claude.com/claude-code)