### PR TITLE
token: allow uncompressed literal runs larger than CHUNK_SIZE

### DIFF
--- a/token.c
+++ b/token.c
@@ -292,14 +292,10 @@ static int32 simple_recv_token(int f, char **data)
 		int32 i = read_int(f);
 		if (i <= 0)
 			return i;
-		/* simple_send_token caps each literal chunk at CHUNK_SIZE;
-		 * reject anything larger so a hostile peer cannot drive the
-		 * read_buf below past our static CHUNK_SIZE buffer. */
-		if (i > CHUNK_SIZE) {
-			rprintf(FERROR, "invalid uncompressed token length %ld [%s]\n",
-				(long)i, who_am_i());
-			exit_cleanup(RERR_PROTOCOL);
-		}
+		/* A literal run may exceed CHUNK_SIZE: some peers (e.g. the
+		 * acrosync library) use a 64k block size.  The loop below reads
+		 * the run CHUNK_SIZE bytes at a time, so read_buf never writes
+		 * past the static CHUNK_SIZE buffer regardless of i. */
 		residue = i;
 	}
 


### PR DESCRIPTION
The hardening in c44c90e9 added a check in simple_recv_token() rejecting any uncompressed literal-run length > CHUNK_SIZE (32k). That assumption breaks interoperability: other rsync implementations -- e.g. the acrosync library used by the iOS "PhotoBackup" app -- use a 64k block size and send literal runs of 65536 bytes, which 3.4.3+ now rejects with "invalid uncompressed token length 65536".

The check was unnecessary: simple_recv_token() already reads the run CHUNK_SIZE bytes at a time via the residue loop (n = MIN(CHUNK_SIZE, residue)), so read_buf() never writes past the static CHUNK_SIZE buffer regardless of the wire-supplied length. Drop the check to restore interop; the compressed-token integer-overflow fix from c44c90e9 (the MAX_TOKEN_INDEX / rx_token caps) is left unchanged.

Fixes #1002
Reported-by: Jack Whitham