### PR TITLE
wildtest: don't read past the buffer when scanning a test line

### DIFF
--- a/wildtest.c
+++ b/wildtest.c
@@ -163,14 +163,17 @@ main(int argc, char **argv)
 		flag[i] = 0;
 	    else
 		flag[i] = -1;
-	    if (*++s != ' ' && *s != '\t')
+	    if (!*s || (*++s != ' ' && *s != '\t'))
 		flag[i] = -1;
 	    if (flag[i] < 0) {
 		fprintf(stderr, "Invalid flag syntax on line %d of %s:\n%s",
 			line, *argv, buf);
 		exit(1);
 	    }
-	    while (*++s == ' ' || *s == '\t') {}
+	    if (*s)
+		s++;
+	    while (*s == ' ' || *s == '\t')
+		s++;
 	}
 	for (i = 0; i <= 1; i++) {
 	    if (*s == '\'' || *s == '"' || *s == '`') {
@@ -194,7 +197,10 @@ main(int argc, char **argv)
 		while (*++s && *s != ' ' && *s != '\t' && *s != '\n') {}
 		end[i] = s;
 	    }
-	    while (*++s == ' ' || *s == '\t') {}
+	    if (*s)
+		s++;
+	    while (*s == ' ' || *s == '\t')
+		s++;
 	}
 	*end[0] = *end[1] = '\0';
 	run_test(line, flag[0],


### PR DESCRIPTION
main()'s line parser stepped through the fgets() buffer with `*++s` in three places without first checking for the terminating NUL, so a test line whose last token runs to the end of the buffer (e.g. a final line with no trailing newline) could advance s past the NUL and read out of bounds.

Guard the flag-separator check and rewrite the two whitespace-skip loops so they never step past the NUL. No behaviour change for well-formed input: the existing wildtest.txt still passes, and the crafted overflow input is now clean under valgrind.

Fixes #776
Reported-by: vikk777 (@vikk777)