### PR TITLE
more valgrind fixes

### DIFF
--- a/generator.c
+++ b/generator.c
@@ -1230,7 +1230,7 @@ static void recv_generator(char *fname, struct file_struct *file, int ndx,
 	static int need_fuzzy_dirlist = 0;
 	struct file_struct *fuzzy_file = NULL;
 	int fd = -1, f_copy = -1;
-	stat_x sx, real_sx;
+	stat_x sx = {0}, real_sx;
 	STRUCT_STAT partial_st;
 	struct file_struct *back_file = NULL;
 	int statret, real_ret, stat_errno;
@@ -1628,6 +1628,10 @@ static void recv_generator(char *fname, struct file_struct *file, int ndx,
 	 || (preserve_specials && ftype == FT_SPECIAL)) {
 		dev_t rdev;
 		int del_for_flag;
+		/* Whether the dest existed, captured before the type-mismatch
+		 * flip below clears statret -- so atomic_create() gets a delete
+		 * flag (and reads sx.st) only when sx.st was actually stat'd. */
+		int dest_existed = (statret == 0);
 		if (ftype == FT_DEVICE) {
 			uint32 *devp = F_RDEV_P(file);
 			rdev = MAKEDEV(DEV_MAJOR(devp), DEV_MINOR(devp));
@@ -1674,7 +1678,7 @@ static void recv_generator(char *fname, struct file_struct *file, int ndx,
 				fname, (int)file->mode,
 				(long)major(rdev), (long)minor(rdev));
 		}
-		if (atomic_create(file, fname, NULL, NULL, rdev, &sx, del_for_flag)) {
+		if (atomic_create(file, fname, NULL, NULL, rdev, &sx, dest_existed ? del_for_flag : 0)) {
 			set_file_attrs(fname, file, NULL, NULL, 0);
 			if (itemizing) {
 				itemize(fnamecmp, file, ndx, statret, &sx,

--- a/runtests.py
+++ b/runtests.py
@@ -266,7 +266,14 @@ def build_rsync_cmd(rsync_bin, args, scratchbase):
     """Build the RSYNC command string for tests."""
     parts = []
     if args.valgrind:
-        vlog = os.path.join(scratchbase, 'valgrind.%p.log')
+        # Logs go in a world-writable+sticky subdir so that rsync children
+        # which drop privileges (the setpriv cap-drop in partial_nowrite, a
+        # daemon dropping to the module's uid) can still create their log file
+        # even when scratchbase itself is root-owned.
+        vgdir = os.path.join(scratchbase, 'valgrind-logs')
+        os.makedirs(vgdir, exist_ok=True)
+        os.chmod(vgdir, 0o1777)
+        vlog = os.path.join(vgdir, 'valgrind.%p.log')
         vopts = f'--log-file={vlog}'
         supp = os.path.join(os.path.dirname(os.path.abspath(__file__)),
                             'testsuite', 'valgrind.supp')
@@ -454,7 +461,7 @@ def main():
     print(f'    os={subprocess.check_output(["uname", "-a"], text=True).strip()}')
     print(f'    preserve_scratch={"yes" if args.preserve_scratch else "no"}')
     if args.valgrind:
-        print(f'    valgrind=enabled (logs in valgrind.*.log)')
+        print(f'    valgrind=enabled (logs in valgrind-logs/valgrind.*.log)')
     if args.parallel > 1:
         print(f'    parallel={args.parallel}')
     print(f'    daemon_transport={"tcp (loopback)" if args.use_tcp else "pipe (secure default)"}')
@@ -620,7 +627,7 @@ def main():
     # Check valgrind logs for errors
     vg_errors = 0
     if args.valgrind:
-        for vlog in sorted(glob.glob(os.path.join(scratchbase, 'valgrind.*.log'))):
+        for vlog in sorted(glob.glob(os.path.join(scratchbase, 'valgrind-logs', 'valgrind.*.log'))):
             try:
                 with open(vlog) as f:
                     content = f.read()
@@ -644,7 +651,7 @@ def main():
     if skipped > 0:
         print(f'      {skipped} skipped')
     if vg_errors > 0:
-        print(f'      {vg_errors} valgrind error(s) found (see logs in {scratchbase})')
+        print(f'      {vg_errors} valgrind error(s) found (see logs in {os.path.join(scratchbase, "valgrind-logs")})')
 
     if expect is not None:
         # Version-mixing mode: the run is judged purely on whether each test's

--- a/testsuite/valgrind.supp
+++ b/testsuite/valgrind.supp
@@ -25,35 +25,6 @@
    fun:main
 }
 
-# rwrite() strlcpy()s a peer log message.  read_a_msg() hands it exactly
-# msg_bytes valid bytes with no terminating NUL; the copy is bounded to len,
-# but strlcpy over-reads past the message to compute its (discarded) return
-# length.  Harmless read of one+ uninitialised stack byte.
-{
-   rsync-rwrite-strlcpy-peer-msg
-   Memcheck:Cond
-   fun:strlcpy
-   fun:strlcpy
-   fun:rwrite
-}
-
-# atomic_create()/delete_item() test sxp->st.st_mode when replacing an
-# existing item.  Under fakeroot the faked stat overlay leaves mode bits that
-# valgrind treats as uninitialised.  Pre-existing hard-link code; fakeroot
-# artifact, not an rsync read of uninitialised memory.
-{
-   rsync-atomic-create-stmode
-   Memcheck:Cond
-   fun:atomic_create
-   fun:recv_generator
-}
-{
-   rsync-delete-item-stmode
-   Memcheck:Cond
-   fun:delete_item
-   fun:atomic_create
-}
-
 # libxxhash returns an internally-aligned XXH3 state whose pointer is offset
 # from the malloc base, so valgrind sees only an interior pointer and reports
 # the one-time checksum state as "possibly lost".  Alignment artifact.


### PR DESCRIPTION
fix an uninitialized read on a failed stat path and avoid false valgrind errors with the valgrind log paths