### PR TITLE
cleanups from scan-build results

### DIFF
--- a/.github/workflows/scan-build.yml
+++ b/.github/workflows/scan-build.yml
@@ -14,9 +14,15 @@ on:
   workflow_dispatch:
 
 jobs:
-  scan-build:
-    runs-on: ubuntu-latest
-    name: rsync scan-build (clang analyzer)
+  # PINNED run: clang-18 on a pinned runner (ubuntu-24.04, whose apt repos carry
+  # clang-18/clang-tools-18) so the checker set -- and thus the report -- is
+  # deterministic.  Informational for now: the tree still has known clang-18
+  # findings, so this surfaces the report without blocking.  Once the tree is at
+  # zero for clang-18, re-add --status-bugs to the scan-build step below to turn
+  # this back into a gate.
+  pinned-clang18:
+    runs-on: ubuntu-24.04
+    name: scan-build (clang-18, pinned)
     steps:
     - uses: actions/checkout@v4
       with:
@@ -24,28 +30,57 @@ jobs:
     - name: prep
       run: |
         sudo apt-get update
-        sudo apt-get install -y clang clang-tools acl libacl1-dev attr libattr1-dev liblz4-dev libzstd-dev libxxhash-dev openssl
+        sudo apt-get install -y clang-18 clang-tools-18 acl libacl1-dev attr libattr1-dev liblz4-dev libzstd-dev libxxhash-dev libpopt-dev openssl
     - name: configure (under scan-build)
       # Run configure under scan-build so its analyzer compiler-wrapper is baked
       # into the Makefile's $(CC); --disable-md2man avoids the doc toolchain.
-      run: scan-build ./configure --with-rrsync --disable-md2man
-    - name: scan-build (informational)
-      # Static analysis only -- INFORMATIONAL, not a gate.  rsync currently has
-      # a fair number of reports that are overwhelmingly known false positives
-      # (e.g. unix.Chroot "no chdir after chroot", core.NonNullParamChecker
-      # against functions that can't actually receive NULL).  We publish the
-      # HTML report as an artifact and print the bug count to the run summary,
-      # but do NOT pass --status-bugs, so this surfaces new analyzer findings
-      # without going red on arrival.  check-progs builds rsync + the test
-      # helpers without needing the man-page toolchain.
+      run: scan-build-18 ./configure --with-rrsync --disable-md2man
+    - name: scan-build (pinned clang-18)
+      # Informational: no --status-bugs, so existing findings don't fail the
+      # build; the report is summarised and uploaded for triage.  Re-add
+      # --status-bugs here (and 'set -o pipefail; ...; exit $status') to gate
+      # once the tree is at zero for clang-18.
       run: |
-        scan-build -o "$PWD/scan-report" make check-progs -j"$(nproc)" 2>&1 | tee scan-build.out
-        echo '## scan-build summary' >>"$GITHUB_STEP_SUMMARY"
+        scan-build-18 -o "$PWD/scan-report" make check-progs -j"$(nproc)" 2>&1 | tee scan-build.out
+        echo '## scan-build (clang-18, pinned)' >>"$GITHUB_STEP_SUMMARY"
         grep -E 'scan-build: .* bugs? found|scan-build: No bugs found' scan-build.out >>"$GITHUB_STEP_SUMMARY" || true
     - name: upload report
       if: always()
       uses: actions/upload-artifact@v4
       with:
-        name: scan-build-report
+        name: scan-build-report-clang18
+        path: scan-report
+        if-no-files-found: ignore
+
+  # INFORMATIONAL run: whatever clang ubuntu-latest currently ships.  Newer
+  # clang releases enable extra, FP-heavy checkers that the gate deliberately
+  # avoids, so this is NOT a gate (no --status-bugs).  It surfaces what the
+  # newest analyzer sees -- useful for spotting genuine new findings before a
+  # gate bump -- without blocking merges.  continue-on-error keeps a noisy or
+  # broken run from affecting the workflow's required status.
+  informational-latest:
+    runs-on: ubuntu-latest
+    name: scan-build (latest clang, informational)
+    continue-on-error: true
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+    - name: prep
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y clang clang-tools acl libacl1-dev attr libattr1-dev liblz4-dev libzstd-dev libxxhash-dev libpopt-dev openssl
+    - name: configure (under scan-build)
+      run: scan-build ./configure --with-rrsync --disable-md2man
+    - name: scan-build (informational)
+      run: |
+        scan-build -o "$PWD/scan-report" make check-progs -j"$(nproc)" 2>&1 | tee scan-build.out
+        echo '## scan-build informational (latest clang)' >>"$GITHUB_STEP_SUMMARY"
+        grep -E 'scan-build: .* bugs? found|scan-build: No bugs found' scan-build.out >>"$GITHUB_STEP_SUMMARY" || true
+    - name: upload report
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: scan-build-report-latest
         path: scan-report
         if-no-files-found: ignore

--- a/batch.c
+++ b/batch.c
@@ -194,7 +194,7 @@ static int write_opt(const char *opt, const char *arg)
 {
 	int len = strlen(opt);
 	int err = write(batch_sh_fd, " ", 1) != 1;
-	err = write(batch_sh_fd, opt, len) != len ? 1 : 0;
+	err |= write(batch_sh_fd, opt, len) != len;
 	if (arg) {
 		err |= write(batch_sh_fd, "=", 1) != 1;
 		err |= write_arg(arg);

--- a/clientserver.c
+++ b/clientserver.c
@@ -270,11 +270,14 @@ int start_inband_exchange(int f_in, int f_out, const char *user, int argc, char 
 		FILE *f = fopen(early_input_file, "rb");
 		if (!f || do_fstat(fileno(f), &st) < 0) {
 			rsyserr(FERROR, errno, "failed to open %s", early_input_file);
+			if (f)
+				fclose(f);
 			return -1;
 		}
 		early_input_len = st.st_size;
 		if (early_input_len > (int)sizeof line) {
 			rprintf(FERROR, "%s is > %d bytes.\n", early_input_file, (int)sizeof line);
+			fclose(f);
 			return -1;
 		}
 		if (early_input_len > 0) {
@@ -283,6 +286,7 @@ int start_inband_exchange(int f_in, int f_out, const char *user, int argc, char 
 				int len;
 				if (feof(f)) {
 					rprintf(FERROR, "Early EOF in %s\n", early_input_file);
+					fclose(f);
 					return -1;
 				}
 				len = fread(line, 1, early_input_len, f);

--- a/getgroups.c
+++ b/getgroups.c
@@ -57,5 +57,6 @@
 		printf("%lu", (unsigned long)gid);
 	printf("\n");
 
+	free(list);
 	return 0;
 }

--- a/hashtable.c
+++ b/hashtable.c
@@ -120,7 +120,7 @@ void *hashtable_find(struct hashtable *tbl, int64 key, void *data_when_new)
 
 	if (!key64) {
 		/* Based on Jenkins One-at-a-time hash. */
-		uchar buf[4], *keyp = buf;
+		uchar buf[4] = {0}, *keyp = buf; /* {0} only to satisfy the analyzer (SIVALu fills buf) */
 		int i;
 
 		SIVALu(buf, 0, key);

--- a/io.c
+++ b/io.c
@@ -2163,7 +2163,7 @@ void write_int(int f, int32 x)
 
 void write_varint(int f, int32 x)
 {
-	char b[5];
+	char b[5] = {0}; /* {0} only to satisfy the analyzer: it doesn't model SIVAL initialising b[1..4] */
 	uchar bit;
 	int cnt;
 
@@ -2185,7 +2185,7 @@ void write_varint(int f, int32 x)
 
 void write_varlong(int f, int64 x, uchar min_bytes)
 {
-	char b[9];
+	char b[9] = {0}; /* {0} only to satisfy the analyzer: it doesn't model SIVAL64 initialising b[1..8] */
 	uchar bit;
 	int cnt = 8;
 

--- a/options.c
+++ b/options.c
@@ -1489,7 +1489,6 @@ int parse_arguments(int *argc_p, const char ***argv_p)
 				*argc_p = 0;
 			} else if (poptDupArgv(argc, argv, argc_p, argv_p) != 0)
 				out_of_memory("parse_arguments");
-			argv = *argv_p;
 			poptFreeContext(pc);
 
 			am_starting_up = 0;

--- a/simd-checksum-x86_64.cpp
+++ b/simd-checksum-x86_64.cpp
@@ -488,8 +488,8 @@ static inline uint32 get_checksum1_cpp(char *buf1, int32 len)
     // multiples of 32 bytes using SSE2 (if available)
     i = get_checksum1_sse2_32((schar*)buf1, len, i, &s1, &s2);
 
-    // whatever is left
-    i = get_checksum1_default_1((schar*)buf1, len, i, &s1, &s2);
+    // whatever is left (updates s1/s2; the returned offset is unused here)
+    get_checksum1_default_1((schar*)buf1, len, i, &s1, &s2);
 
     return (s1 & 0xffff) + (s2 << 16);
 }

--- a/socket.c
+++ b/socket.c
@@ -802,7 +802,8 @@ static int socketpair_tcp(int fd[2])
 	 * the local address of our connecting end (fd[1]), and both must be
 	 * loopback.  If they differ, someone else connected first; fail closed. */
 	{
-		struct sockaddr_in accepted_peer, our_local;
+		/* {0}: the analyzer doesn't model getpeername/getsockname filling these. */
+		struct sockaddr_in accepted_peer = {0}, our_local = {0};
 		socklen_t plen = sizeof accepted_peer;
 		socklen_t llen = sizeof our_local;
 

--- a/util1.c
+++ b/util1.c
@@ -524,7 +524,7 @@ int robust_unlink(const char *fname)
 		snprintf(&path[pos], MAX_RENAMES_DIGITS+1, "%03d", counter);
 		if (++counter >= MAX_RENAMES)
 			counter = 1;
-	} while ((rc = access(path, 0)) == 0 && counter != start);
+	} while (access(path, 0) == 0 && counter != start);
 
 	if (INFO_GTE(MISC, 1)) {
 		rprintf(FWARNING, "renaming %s to %s because of text busy\n",

--- a/wildtest.c
+++ b/wildtest.c
@@ -210,6 +210,8 @@ main(int argc, char **argv)
 		 string[0], string[1]);
     }
 
+    fclose(fp);
+
     if (!wildmatch_errors)
 	fputs("No", stdout);
     else


### PR DESCRIPTION
the clang scan-build linter gave several non-critical warnings that are fixed here. 
clang-18 scan-build is not yet gating, hopefully we'll get it gating in CI soon
