### PR TITLE
Fix Solaris xattr write loop after partial write

### DIFF
--- a/lib/sysxattrs.c
+++ b/lib/sysxattrs.c
@@ -227,7 +227,7 @@ int sys_lsetxattr(const char *path, const char *name, const void *value, size_t 
 		return -1;
 
 	for (bufpos = 0; bufpos < size; ) {
-		ssize_t cnt = write(attrfd, (char*)value + bufpos, size);
+		ssize_t cnt = write(attrfd, (char*)value + bufpos, size - bufpos);
 		if (cnt <= 0) {
 			if (cnt < 0 && errno == EINTR)
 				continue;


### PR DESCRIPTION
This fixes a bug in the Solaris xattr backend's retry loop.

In `lib/sysxattrs.c`, the loop advances `bufpos` after a successful partial write, but subsequent retries continue to pass the original `size` value to `write()` rather than the remaining byte count.

As a result, if a short write occurs, the next iteration can attempt to write more bytes than remain in the source buffer.

The fix changes:

```c
write(attrfd, (char*)value + bufpos, size);
```

to:

```c
write(attrfd, (char*)value + bufpos, size - bufpos);
```

This matches the corresponding logic in `read_xattr()` and the existing retry-loop pattern used elsewhere in the file.

Notes:

* Solaris-specific code path
* No behavioral changes on successful full writes
* Build and test results unchanged after the fix
* The issue appears to date back to the initial Solaris xattr implementation
