### PR TITLE
Fixed as Per Request in prior PR https://github.com/RsyncProject/rsync/pull/1013

### DIFF
--- a/lib/sysxattrs.c
+++ b/lib/sysxattrs.c
@@ -227,19 +227,19 @@ int sys_lsetxattr(const char *path, const char *name, const void *value, size_t 
 		return -1;
 
 	for (bufpos = 0; bufpos < size; ) {
-		ssize_t cnt = write(attrfd, (char*)value + bufpos, size);
+		ssize_t cnt = write(attrfd, (char*)value + bufpos, size - bufpos);
 		if (cnt <= 0) {
 			if (cnt < 0 && errno == EINTR)
 				continue;
-			bufpos = -1;
-			break;
+			close(attrfd);
+			return -1;
 		}
 		bufpos += cnt;
 	}
 
 	close(attrfd);
 
-	return bufpos > 0 ? 0 : -1;
+	return 0;
 }
 
 int sys_lremovexattr(const char *path, const char *name)


### PR DESCRIPTION
Update:

During review it was pointed out that the Solaris write loop also uses
`bufpos = -1` as an error sentinel even though `bufpos` is a `size_t`.

This wraps to `SIZE_MAX`, allowing the final return expression to
report success after a failed write.

The updated patch returns `-1` directly on non-retryable write errors
instead of using a sentinel value.
