### PR TITLE
syscall: build without AT_SYMLINK_NOFOLLOW

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -65,12 +65,18 @@ CHECK_SYMLINKS = testsuite/chown-fake_test.py testsuite/devices-fake_test.py \
 
 # Objects for CHECK_PROGS to clean
 CHECK_OBJS=tls.o testrun.o getgroups.o getfsdev.o t_stub.o t_unsafe.o t_chmod_secure.o t_secure_relpath.o trimslash.o wildtest.o
+# Compile-only feature-shape checks.
+CHECK_COMPILE_OBJS=syscall-no-at-fdcwd.o
 
 # note that the -I. is needed to handle config.h when using VPATH
 .c.o:
 @OBJ_SAVE@
 	$(CC) -I. -I$(srcdir) $(CFLAGS) $(CPPFLAGS) -c $< @CC_SHOBJ_FLAG@
 @OBJ_RESTORE@
+
+syscall-no-at-fdcwd.o: syscall.c $(HEADERS)
+	$(CC) -I. -I$(srcdir) $(CFLAGS) $(CPPFLAGS) \
+	    -DRSYNC_TEST_NO_AT_FDCWD -c $(srcdir)/syscall.c -o $@
 
 # NOTE: consider running "packaging/smart-make" instead of "make" to auto-handle
 # any changes to configure.sh and the main Makefile prior to a "make all".
@@ -300,7 +306,7 @@ rrsync.1: support/rrsync.1.md md-convert Makefile
 
 .PHONY: clean
 clean: cleantests
-	rm -f *~ $(OBJS) $(CHECK_PROGS) $(CHECK_OBJS) $(CHECK_SYMLINKS) @MAKE_RRSYNC@ \
+	rm -f *~ $(OBJS) $(CHECK_PROGS) $(CHECK_OBJS) $(CHECK_COMPILE_OBJS) $(CHECK_SYMLINKS) @MAKE_RRSYNC@ \
 		git-version.h rounding rounding.h *.old rsync*.1 rsync*.5 @MAKE_RRSYNC_1@ \
 		*.html daemon-parm.h help-*.h default-*.h proto.h proto.h-tstamp
 	rm -f *.gcno *.gcda lib/*.gcno lib/*.gcda zlib/*.gcno zlib/*.gcda popt/*.gcno popt/*.gcda
@@ -378,18 +384,18 @@ COVERAGE_EXCLUDE = -e '(^|/)zlib/' -e '(^|/)popt/' \
 # WITHOUT running it. Used by CI jobs that invoke runtests.py directly with
 # custom options (e.g. the version-mix workflow's --rsync-bin2/--expect-result).
 .PHONY: check-progs
-check-progs: all $(CHECK_PROGS) $(CHECK_SYMLINKS)
+check-progs: all $(CHECK_PROGS) $(CHECK_COMPILE_OBJS) $(CHECK_SYMLINKS)
 
 .PHONY: check
-check: all $(CHECK_PROGS) $(CHECK_SYMLINKS)
+check: all $(CHECK_PROGS) $(CHECK_COMPILE_OBJS) $(CHECK_SYMLINKS)
 	$(srcdir)/runtests.py --rsync-bin=`pwd`/rsync$(EXEEXT) -j $(CHECK_J)
 
 .PHONY: check29
-check29: all $(CHECK_PROGS) $(CHECK_SYMLINKS)
+check29: all $(CHECK_PROGS) $(CHECK_COMPILE_OBJS) $(CHECK_SYMLINKS)
 	$(srcdir)/runtests.py --rsync-bin=`pwd`/rsync$(EXEEXT) -j $(CHECK_J) --protocol=29
 
 .PHONY: check30
-check30: all $(CHECK_PROGS) $(CHECK_SYMLINKS)
+check30: all $(CHECK_PROGS) $(CHECK_COMPILE_OBJS) $(CHECK_SYMLINKS)
 	$(srcdir)/runtests.py --rsync-bin=`pwd`/rsync$(EXEEXT) -j $(CHECK_J) --protocol=30
 
 # Whole-suite gcov coverage report (HTML, with branch + decision coverage).

--- a/Makefile.in
+++ b/Makefile.in
@@ -74,14 +74,14 @@ CHECK_COMPILE_OBJS=syscall-no-at-fdcwd.o
 	$(CC) -I. -I$(srcdir) $(CFLAGS) $(CPPFLAGS) -c $< @CC_SHOBJ_FLAG@
 @OBJ_RESTORE@
 
-syscall-no-at-fdcwd.o: syscall.c $(HEADERS)
-	$(CC) -I. -I$(srcdir) $(CFLAGS) $(CPPFLAGS) \
-	    -DRSYNC_TEST_NO_AT_FDCWD -c $(srcdir)/syscall.c -o $@
-
 # NOTE: consider running "packaging/smart-make" instead of "make" to auto-handle
 # any changes to configure.sh and the main Makefile prior to a "make all".
 all: Makefile rsync$(EXEEXT) stunnel-rsyncd.conf @MAKE_RRSYNC@ @MAKE_MAN@
 .PHONY: all
+
+syscall-no-at-fdcwd.o: syscall.c $(HEADERS)
+	$(CC) -I. -I$(srcdir) $(CFLAGS) $(CPPFLAGS) \
+	    -DRSYNC_TEST_NO_AT_FDCWD -c $(srcdir)/syscall.c -o $@
 
 .PHONY: install
 install: all

--- a/syscall.c
+++ b/syscall.c
@@ -27,7 +27,9 @@
 #undef AT_FDCWD
 #undef AT_SYMLINK_NOFOLLOW
 #undef HAVE_LINKAT
+#undef HAVE_OPENAT2
 #undef HAVE_UTIMENSAT
+#undef O_RESOLVE_BENEATH
 #endif
 
 #if !defined MKNOD_CREATES_SOCKETS && defined HAVE_SYS_UN_H

--- a/syscall.c
+++ b/syscall.c
@@ -22,6 +22,14 @@
 
 #include "rsync.h"
 
+/* Exercise the pre-*at() portability tier on modern build hosts. */
+#ifdef RSYNC_TEST_NO_AT_FDCWD
+#undef AT_FDCWD
+#undef AT_SYMLINK_NOFOLLOW
+#undef HAVE_LINKAT
+#undef HAVE_UTIMENSAT
+#endif
+
 #if !defined MKNOD_CREATES_SOCKETS && defined HAVE_SYS_UN_H
 #include <sys/un.h>
 #endif
@@ -426,7 +434,7 @@ int do_lchown(const char *path, uid_t owner, gid_t group)
 */
 int do_lchown_at(const char *fname, uid_t owner, gid_t group)
 {
-#ifdef AT_FDCWD
+#if defined AT_FDCWD && defined AT_SYMLINK_NOFOLLOW
 	extern int am_daemon, am_chrooted;
 	char dirpath[MAXPATHLEN];
 	const char *bname;
@@ -1181,6 +1189,7 @@ static int do_xstat_at(const char *path, STRUCT_STAT *st, int at_flags, int (*fa
 	errno = e;
 	return ret;
 #else
+	(void)at_flags;
 	return fallback(path, st);
 #endif
 }
@@ -1192,8 +1201,10 @@ int do_stat_at(const char *path, STRUCT_STAT *st)
 
 int do_lstat_at(const char *path, STRUCT_STAT *st)
 {
-#ifdef SUPPORT_LINKS
+#if defined SUPPORT_LINKS && defined AT_FDCWD && defined AT_SYMLINK_NOFOLLOW
 	return do_xstat_at(path, st, AT_SYMLINK_NOFOLLOW, do_lstat);
+#elif defined SUPPORT_LINKS
+	return do_lstat(path, st);
 #else
 	return do_xstat_at(path, st, 0, do_stat);
 #endif
@@ -2007,6 +2018,7 @@ cleanup:
 #endif // O_NOFOLLOW, O_DIRECTORY
 }
 
+#if defined O_NOFOLLOW && defined O_DIRECTORY && defined AT_FDCWD
 /* Fill buf with len random bytes.  Prefers /dev/urandom for cryptographic
  * quality; falls back to rand() if /dev/urandom cannot be opened or read
  * (e.g. inside a chroot or container without /dev populated). */
@@ -2027,6 +2039,7 @@ static void rand_bytes(unsigned char *buf, size_t len)
 		buf[i] = (unsigned char)rand();
 	}
 }
+#endif
 
 /*
   Secure version of mkstemp that prevents symlink attacks on parent directories.


### PR DESCRIPTION
Addresses the upstream portion of #1025.

`do_lstat_at()` selected its `fstatat()` implementation whenever symlink support was enabled. Older systems such as macOS 10.6 support symlinks but do not define `AT_FDCWD` or `AT_SYMLINK_NOFOLLOW` so the unconditional reference to `AT_SYMLINK_NOFOLLOW` prevented `syscall.c` from compiling. This falls back to `do_lstat()` unless both `AT_FDCWD` and `AT_SYMLINK_NOFOLLOW` are available. The same availability check is applied to `do_lchown_at()` because its `fchownat()` implementation also requires `AT_SYMLINK_NOFOLLOW`.