### PR TITLE
util: restore ".." collapsing in clean_fname()

### DIFF
--- a/testsuite/clean-fname-collapse_test.py
+++ b/testsuite/clean-fname-collapse_test.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+"""Regression test for clean_fname()'s ".." collapsing.
+
+clean_fname(name, CFN_COLLAPSE_DOT_DOT_DIRS) is rsync's canonical path
+normalizer.  Commit 9e089846 ("util: fixed issue in clean_fname()") fixed a
+read-before-buffer in the ".." back-up loop, but the new loop leaves 's'
+pointing at the *start* of the preceding component (just past its '/'),
+whereas the old loop left it *at* the '/'.  The surrounding test and
+assignment (`*s == '/'` / `t = s + 1`) were not adjusted for that one-byte
+shift, so the collapse silently stopped working for every path except a
+single leading no-slash component:
+
+    a/../b              -> b          (still worked)
+    /a/../b             -> /a/../b    (BROKEN: should be /b)
+    a/b/../c            -> a/b/../c   (BROKEN: should be a/c)
+    x/y/../../z         -> x/y/../../z(BROKEN: should be z)
+
+We exercise it through a merge-filter filename, one of the callers that pass
+CFN_COLLAPSE_DOT_DOT_DIRS.  The filter file lives at "a/c"; we reference it as
+"a/none/../c" where the "none" directory does NOT exist.  A correct collapse
+turns that into "a/c" (which opens), so the filter is read and applied; the
+buggy code leaves the literal "a/none/../c", which fails to open (ENOENT) and
+aborts the whole run.  This is also a faithful reproduction of the user-facing
+regression: merge/exclude files referenced via a path containing "..".
+"""
+
+import os
+
+from rsyncfns import (
+    FROMDIR, TODIR, rmtree, run_rsync, test_fail,
+)
+
+rmtree(FROMDIR)
+rmtree(TODIR)
+FROMDIR.mkdir(parents=True, exist_ok=True)
+TODIR.mkdir(parents=True, exist_ok=True)
+
+# Source: one file to keep, one the filter should drop.
+(FROMDIR / 'keep.txt').write_text('keep\n')
+(FROMDIR / 'drop.skip').write_text('drop\n')
+
+# Merge-filter file at a/c; note that a/none does NOT exist, so the path
+# "a/none/../c" only resolves if rsync collapses ".." to a plain "a/c".
+adir = TODIR.parent / 'a'
+rmtree(adir)
+adir.mkdir(parents=True, exist_ok=True)
+(adir / 'c').write_text('- *.skip\n')
+
+saved = os.getcwd()
+os.chdir(TODIR.parent)
+try:
+    proc = run_rsync('-a', '--filter=merge a/none/../c',
+                     f'{FROMDIR}/', f'{TODIR}/', check=False)
+finally:
+    os.chdir(saved)
+
+if proc.returncode != 0:
+    test_fail(
+        "rsync failed to open the merge filter via 'a/none/../c'; "
+        "clean_fname() did not collapse '..' (regression of 9e089846)")
+
+if not (TODIR / 'keep.txt').is_file():
+    test_fail("keep.txt was not transferred")
+if (TODIR / 'drop.skip').exists():
+    test_fail("drop.skip was transferred -- the merge filter was not applied, "
+              "so clean_fname() resolved the filter path to the wrong file")
+
+print("OK: clean_fname() collapsed 'a/none/../c' -> 'a/c' and the filter applied")

--- a/testsuite/clean-fname-collapse_test.py
+++ b/testsuite/clean-fname-collapse_test.py
@@ -46,23 +46,56 @@ rmtree(adir)
 adir.mkdir(parents=True, exist_ok=True)
 (adir / 'c').write_text('- *.skip\n')
 
-saved = os.getcwd()
-os.chdir(TODIR.parent)
-try:
-    proc = run_rsync('-a', '--filter=merge a/none/../c',
-                     f'{FROMDIR}/', f'{TODIR}/', check=False)
-finally:
-    os.chdir(saved)
+# Interior collapse only exercises the case where the ".." eats a component
+# that has a '/' before it.  Two more filter files pin the other two branches:
+# 'f1' for a leading component (the s == name case, where there is no earlier
+# '/' to find) and 'updir' for a leading ".." that must NOT be collapsed away.
+(TODIR.parent / 'f1').write_text('- *.skip\n')
+(TODIR.parent / 'updir').write_text('- *.skip\n')
+deepdir = TODIR.parent / 'sub1' / 'sub2'
+rmtree(deepdir)
+deepdir.mkdir(parents=True, exist_ok=True)
 
-if proc.returncode != 0:
-    test_fail(
-        "rsync failed to open the merge filter via 'a/none/../c'; "
-        "clean_fname() did not collapse '..' (regression of 9e089846)")
 
-if not (TODIR / 'keep.txt').is_file():
-    test_fail("keep.txt was not transferred")
-if (TODIR / 'drop.skip').exists():
-    test_fail("drop.skip was transferred -- the merge filter was not applied, "
-              "so clean_fname() resolved the filter path to the wrong file")
+def check(rundir, filter_path, what):
+    """Run with the merge filter named via `filter_path` and require that the
+    file was found *and* applied.  Each name only resolves when clean_fname()
+    collapses (or preserves) the ".." exactly right; get it wrong and the open
+    fails or lands on a different file, so nothing filters *.skip out."""
+    rmtree(TODIR)
+    TODIR.mkdir(parents=True, exist_ok=True)
+    saved = os.getcwd()
+    os.chdir(rundir)
+    try:
+        proc = run_rsync('-a', f'--filter=merge {filter_path}',
+                         f'{FROMDIR}/', f'{TODIR}/', check=False)
+    finally:
+        os.chdir(saved)
 
-print("OK: clean_fname() collapsed 'a/none/../c' -> 'a/c' and the filter applied")
+    if proc.returncode != 0:
+        test_fail(f"rsync could not open the merge filter via '{filter_path}' "
+                  f"({what}); clean_fname() mishandled the '..'")
+    if not (TODIR / 'keep.txt').is_file():
+        test_fail(f"keep.txt was not transferred ({what})")
+    if (TODIR / 'drop.skip').exists():
+        test_fail(f"drop.skip was transferred ({what}): the merge filter was "
+                  "not applied, so clean_fname() resolved the filter path to "
+                  "the wrong file")
+
+
+# Interior component: "a/none/../c" -> "a/c" (a/none does not exist).
+check(TODIR.parent, 'a/none/../c', 'interior component')
+
+# Leading component: "zzz/../f1" -> "f1".  Here the back-up reaches the start
+# of the name with no '/' before it, so a bounds slip or an off-by-one in that
+# test stops the collapse (this is the shape the 9e089846 regression left
+# working, and the shape a partial revert breaks).
+check(TODIR.parent, 'zzz/../f1', 'leading component')
+
+# A leading ".." has nothing to collapse into and must be kept: run two levels
+# down and reach back up.  If it were collapsed away the name would resolve
+# inside sub1/sub2, where no such file exists.
+check(deepdir, '../../updir', 'leading ".." preserved')
+
+print("OK: clean_fname() collapsed interior and leading components and kept a "
+      "leading '..'; the merge filter applied in every case")

--- a/util1.c
+++ b/util1.c
@@ -1004,13 +1004,16 @@ int clean_fname(char *name, int flags)
 					f += 2;
 					continue;
 				}
-				/* backing up for ".." — avoid reading before 'name' */
+				/* backing up for ".." — avoid reading before 'name'.
+				 * The loop stops with 's' pointing at the start of the
+				 * preceding component (just past its '/'), or at 'limit'. */
 				while (s > limit && s[-1] != '/')
 					s--;
 
-				/* If found prior '/', or we reached the start, adjust t. */
-				if (s != t - 1 && (s <= name || *s == '/')) {
-					t = (s == name) ? name : s + 1;
+				/* If we backed up over a real component (found a prior
+				 * '/' or reached the start of the name), drop it. */
+				if (s != t - 1 && (s == name || s[-1] == '/')) {
+					t = s;
 					f += 2;
 					continue;
 				}


### PR DESCRIPTION
## Problem

Commit 9e089846 ("util: fixed issue in clean_fname()") fixed a genuine read-before-buffer in the `".."` back-up loop, but the replacement loop stops in a **different place** than the one it replaced, and the surrounding test/assignment were carried over unchanged.

The old loop pre-decremented, so it stopped with `s` pointing **at** the preceding `/`:

```c
while (s > limit && *--s != '/') {}
```

The new loop stops with `s` pointing at the **start of the preceding component**, one byte past that `/`:

```c
while (s > limit && s[-1] != '/')
	s--;
```

But the follow-up is unchanged, so it is now off by one:

```c
if (s != t - 1 && (s <= name || *s == '/')) {
	t = (s == name) ? name : s + 1;
```

`*s` is a component character and is essentially never `/`, so the collapse now only happens via the `s == name` case — a single leading component with no slash before it. **Every other form silently stopped collapsing:**

| input | current | expected |
|---|---|---|
| `a/../b` | `b` | `b` (still worked) |
| `/a/../b` | `/a/../b` | `/b` |
| `a/b/../c` | `a/b/../c` | `a/c` |
| `/usr/local/../bin` | `/usr/local/../bin` | `/usr/bin` |
| `x/y/../../z` | `x/y/../../z` | `z` |
| `one/two/three/../../four` | `one/two/three/../../four` | `one/four` |

## Impact

`clean_fname(..., CFN_COLLAPSE_DOT_DOT_DIRS)` is rsync's canonical path normalizer — used for filter and merge-file names and for the `--backup-dir`, `--partial-dir` and `--temp-dir` options — so any such path containing an interior `..` is left un-normalized.

User-visible example (a merge filter that can only be opened if `..` is collapsed):

```
$ rsync -a --filter='merge a/none/../c' src/ dst/
rsync: [client] failed to open exclude file a/none/../c: No such file or directory (2)
rsync error: error in file IO (code 11) at exclude.c(1482)
```

Before 9e089846 this collapsed to `a/c` and worked.

## Fix

Adjust the two spots for where the new loop actually stops: test the byte **before** `s` for the `/` (or that we reached the start of the name), and set `t = s`.

This **keeps the underflow fix** — `s[-1]` is only read when `s` is past `name`, and the `s == name` test short-circuits — while restoring the long-standing behaviour.

The `CFN_REFUSE_DOT_DOT_DIRS` path returns before this code and is unaffected, as is `sanitize_path()` (the separate daemon-side `..` handler), so this is a path-normalization/file-selection fix, not a security change.

## Test

`testsuite/clean-fname-collapse_test.py` drives the collapse through a merge-filter filename: the filter file lives at `a/c` but is named `a/none/../c` with **no `a/none` directory**, so it can only be opened if `..` is collapsed. It also asserts the filter was actually applied. It **fails before this change and passes after**; full testsuite otherwise unchanged (106 passed, 0 failed).