### PR TITLE
checksum: keep the link alive while hashing a file (fixes #839)

### DIFF
--- a/checksum.c
+++ b/checksum.c
@@ -37,6 +37,7 @@
 
 extern int am_server;
 extern int whole_file;
+extern int allowed_lull;
 extern int checksum_seed;
 extern int protocol_version;
 extern int proper_seed_order;
@@ -398,6 +399,41 @@ void get_checksum2(char *buf, int32 len, char *sum)
 	}
 }
 
+/* Hashing a large file sends nothing to the peer for as long as it takes, so a
+ * --checksum run over a big file looks like a dead link and the far end aborts
+ * once --timeout elapses.  Tick the keep-alive as we go; maybe_send_keepalive()
+ * itself only acts once allowed_lull (half of --timeout) has passed.
+ *
+ * `n` is the size of the piece just hashed, and we only consult the clock once
+ * per CHUNK_SIZE of it.  The MD4 loop feeds us CSUM_CHUNK (64) bytes at a time,
+ * so ticking per piece would call time() 512x more often for MD4 than for the
+ * other digests -- 16.7 million times per GiB, which is cheap on a vDSO clock
+ * and decidedly not on a platform where time() is a real syscall. */
+static void checksum_keepalive(int32 n)
+{
+	static int32 until_tick = CHUNK_SIZE;
+
+	if (!allowed_lull)
+		return;
+	if ((until_tick -= n) > 0)
+		return;
+	until_tick = CHUNK_SIZE;
+	maybe_send_keepalive(time(NULL), MSK_ALLOW_FLUSH);
+}
+
+/* Feed the mapped file to a digest in `chunk`-sized pieces.  UPDATE is an
+ * expression using _p/_n for the piece; the digests have differing signatures,
+ * so an expression is what lets one loop serve all of them.  Each caller keeps
+ * its own trailing-partial-chunk handling, which is not identical across
+ * digests (see the pre-27 MD4 case below). */
+#define CHECKSUM_FEED(chunk, UPDATE) \
+	for (i = 0; i + (chunk) <= len; i += (chunk)) { \
+		const char *_p = map_ptr(buf, i, (chunk)); \
+		int32 _n = (chunk); \
+		UPDATE; \
+		checksum_keepalive(_n); \
+	}
+
 void file_checksum(const char *fname, const STRUCT_STAT *st_p, char *sum)
 {
 	struct map_struct *buf;
@@ -421,8 +457,7 @@ void file_checksum(const char *fname, const STRUCT_STAT *st_p, char *sum)
 
 		EVP_DigestInit_ex(evp, file_sum_evp_md, NULL);
 
-		for (i = 0; i + CHUNK_SIZE <= len; i += CHUNK_SIZE)
-			EVP_DigestUpdate(evp, (uchar *)map_ptr(buf, i, CHUNK_SIZE), CHUNK_SIZE);
+		CHECKSUM_FEED(CHUNK_SIZE, EVP_DigestUpdate(evp, (uchar *)_p, _n));
 
 		remainder = (int32)(len - i);
 		if (remainder > 0)
@@ -440,8 +475,7 @@ void file_checksum(const char *fname, const STRUCT_STAT *st_p, char *sum)
 
 		XXH64_reset(state, 0);
 
-		for (i = 0; i + CHUNK_SIZE <= len; i += CHUNK_SIZE)
-			XXH64_update(state, (uchar *)map_ptr(buf, i, CHUNK_SIZE), CHUNK_SIZE);
+		CHECKSUM_FEED(CHUNK_SIZE, XXH64_update(state, (uchar *)_p, _n));
 
 		remainder = (int32)(len - i);
 		if (remainder > 0)
@@ -459,8 +493,7 @@ void file_checksum(const char *fname, const STRUCT_STAT *st_p, char *sum)
 
 		XXH3_64bits_reset(state);
 
-		for (i = 0; i + CHUNK_SIZE <= len; i += CHUNK_SIZE)
-			XXH3_64bits_update(state, (uchar *)map_ptr(buf, i, CHUNK_SIZE), CHUNK_SIZE);
+		CHECKSUM_FEED(CHUNK_SIZE, XXH3_64bits_update(state, (uchar *)_p, _n));
 
 		remainder = (int32)(len - i);
 		if (remainder > 0)
@@ -477,8 +510,7 @@ void file_checksum(const char *fname, const STRUCT_STAT *st_p, char *sum)
 
 		XXH3_128bits_reset(state);
 
-		for (i = 0; i + CHUNK_SIZE <= len; i += CHUNK_SIZE)
-			XXH3_128bits_update(state, (uchar *)map_ptr(buf, i, CHUNK_SIZE), CHUNK_SIZE);
+		CHECKSUM_FEED(CHUNK_SIZE, XXH3_128bits_update(state, (uchar *)_p, _n));
 
 		remainder = (int32)(len - i);
 		if (remainder > 0)
@@ -495,8 +527,7 @@ void file_checksum(const char *fname, const STRUCT_STAT *st_p, char *sum)
 
 		md5_begin(&m5);
 
-		for (i = 0; i + CHUNK_SIZE <= len; i += CHUNK_SIZE)
-			md5_update(&m5, (uchar *)map_ptr(buf, i, CHUNK_SIZE), CHUNK_SIZE);
+		CHECKSUM_FEED(CHUNK_SIZE, md5_update(&m5, (uchar *)_p, _n));
 
 		remainder = (int32)(len - i);
 		if (remainder > 0)
@@ -513,8 +544,7 @@ void file_checksum(const char *fname, const STRUCT_STAT *st_p, char *sum)
 
 		mdfour_begin(&m);
 
-		for (i = 0; i + CSUM_CHUNK <= len; i += CSUM_CHUNK)
-			mdfour_update(&m, (uchar *)map_ptr(buf, i, CSUM_CHUNK), CSUM_CHUNK);
+		CHECKSUM_FEED(CSUM_CHUNK, mdfour_update(&m, (uchar *)_p, _n));
 
 		/* Prior to version 27 an incorrect MD4 checksum was computed
 		 * by failing to call mdfour_tail() for block sizes that


### PR DESCRIPTION
Alternative to #840 for issue #839 — credit to @tenox7 for the report and for identifying the keepalive as the mechanism. I reproduced the bug, then found #840's version doesn't fix the reported case; details below.

## Reproducing it

With `--checksum` the sender hashes every regular file while building the file list (flist.c calls `file_checksum()` from `make_file()`), and sends **nothing** meanwhile. A single 2 GiB file (~4.3s to hash):

```
$ rsync -a --checksum --timeout=3 rsync://host/mod/ dst/
[Receiver] io timeout after 4 seconds -- exiting
rsync error: timeout in data send/receive (code 30)
```

Controls: the same transfer **without** `--checksum` → fine; `--checksum --timeout=30` → fine; `--checksum` with no timeout → fine. So it is purely the unbroken silence while hashing.

**It's driven by per-file hash time, not file count.** 500,000 small files take 4.6s to hash in total and do *not* trip it, because list entries keep streaming and the link never goes quiet. One big file does.

## Two problems with #840

**1. The hardcoded 5-second interval can't fix the reported case.** I applied #840 and re-ran the reproducer:

| build | `--timeout=3` | `--timeout=6` | `--timeout=12` |
|---|---|---|---|
| master | times out | times out | times out |
| **#840** | **still times out** | fixed | fixed |
| this PR | fixed | fixed | fixed |

With `--timeout=3` the peer has already given up before #840's first keepalive at 5s.

**2. The `am_daemon` gate is too narrow.** The same hang happens over a remote shell:

```
lsh --checksum --timeout=2   master exit=30   this PR exit=0
lsh --checksum --timeout=1   master exit=30   this PR exit=0
```

## This change

rsync already has the right primitive: `maybe_send_keepalive()` sends a `MSG_NOOP` and **self-throttles on `allowed_lull`**, which `set_io_timeout()` computes as *half of `--timeout`* — exactly the interval this needs, at any timeout value. The generator, sender and receiver already call it during their long stretches (`generator.c:296`, `sender.c:116`, `receiver.c:390`); the file-list hashing path simply never did.

`file_checksum()` had **six copies** of the same chunk loop, one per digest — which is why #840 had to patch each. Rather than add the call six times and leave a seventh digest free to forget it, the loop is now a single `CHECKSUM_FEED()` macro carrying the tick.

It takes the update as an *expression* deliberately: the digests have differing signatures (`EVP_DigestUpdate`, `XXH64_update`, `md5_update`, `mdfour_update`), so a function-pointer iterator would need a wrapper per digest, and it could not express the pre-27 MD4 case, which uses `CSUM_CHUNK` and a different tail condition. Each caller keeps its own trailing-partial-chunk handling **unchanged**.

## Verification

- **Digest-identical** to the unpatched build, checked in *both* directions (master sender vs patched receiver and vice versa) over files at the chunk boundaries — 0, 1, 63, 64, 65, 32767, 32768, 32769, 65537 and multi-chunk — for every checksum-choice this build offers, with a flipped byte as a positive control.
- Fixes both the daemon and remote-shell paths, at `--timeout=1` upward.
- Full testsuite: 106 passed, 0 failed.
- I checked `generate_and_send_sums()` for the same pattern: it does **not** need it, because it writes each block sum as it computes, so that link never goes quiet.

**On a regression test:** I deliberately haven't added one. Exercising this needs a multi-GB file and a wall-clock race against `--timeout`, which would be slow and timing-flaky across the CI platforms. Happy to add one if you'd like it, but it seemed worse than documenting the measured reproduction here.