### PR TITLE
rsync-ssl: -verify_ip when connecting to an IP/IPv6 address

### DIFF
--- a/rsync-ssl
+++ b/rsync-ssl
@@ -137,7 +137,19 @@ function rsync_ssl_helper {
     fi
 
     if [[ $RSYNC_SSL_TYPE == openssl ]]; then
-	exec $RSYNC_SSL_OPENSSL s_client $caopt $certopt $keyopt -quiet -verify_quiet -servername $hostname -verify_hostname $hostname -connect $hostname:$port
+	if echo "$hostname" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$|^[0-9a-fA-F:]+$'; then
+	    verify_opt="-verify_ip $hostname"
+	    if echo "$hostname" | grep -q ':'; then
+		# IPv6
+		connect="[$hostname]:$port"
+	    else
+		connect="$hostname:$port"
+	    fi
+	else
+	    verify_opt="-verify_hostname $hostname"
+	    connect="$hostname:$port"
+	fi
+	exec $RSYNC_SSL_OPENSSL s_client $caopt $certopt $keyopt -quiet -verify_quiet -servername $hostname $verify_opt -connect "$connect"
     elif [[ $RSYNC_SSL_TYPE == gnutls ]]; then
 	exec $RSYNC_SSL_GNUTLS --logfile=/dev/null $gnutls_cert_opt $gnutls_key_opt $gnutls_opts $hostname:$port
     else


### PR DESCRIPTION
Fixes:
1. ipcert (Let's Encrypt supports this earlier this year, see [their post](https://letsencrypt.org/2026/01/15/6day-and-ip-general-availability))
```
$ rsync-ssl rsync://192.0.2.1
verify depth is 4
Connecting to 192.0.2.1
depth=0
verify error:num=62:hostname mismatch
40F13FDC967F0000:error:0A000086:SSL routines:tls_post_process_server_certificate:certificate verify failed:../ssl/statem/statem_clnt.c:2103:
rsync: did not see server greeting
rsync error: error starting client-server protocol (code 5) at main.c(1850) [Receiver=3.4.0]
```

2. `openssl s_client -connect 2001:db8::1:874` didn't got properly square-bracketed
```
$ rsync-ssl 'rsync://[2001:db8::1]'
verify depth is 4
s_client: -connect argument or target parameter malformed or ambiguous
rsync: did not see server greeting
rsync error: error starting client-server protocol (code 5) at main.c(1850) [Receiver=3.4.0]
```

```
/usr/bin/openssl s_client [...] -connect 2001:db8::1:874
```

My IPv6 connection is broken so I havn't tested the second case. But it should work.