### PR TITLE
Update COPYING.html (openssl & xxhash exceptions)

### DIFF
--- a/rsync-web/COPYING.html
+++ b/rsync-web/COPYING.html
@@ -1,3 +1,12 @@
+REGARDING OPENSSL AND XXHASH
+
+In addition, as a special exception, the copyright holders give
+permission to dynamically link rsync with the OpenSSL and xxhash
+libraries when those libraries are being distributed in compliance
+with their license terms, and to distribute a dynamically linked
+combination of rsync and these libraries.  This is also considered
+to be covered under the GPL's System Libraries exception.
+
                     GNU GENERAL PUBLIC LICENSE
                        Version 3, 29 June 2007
 
@@ -671,4 +680,4 @@ into proprietary programs.  If your program is a subroutine library, you
 may consider it more useful to permit linking proprietary applications with
 the library.  If this is what you want to do, use the GNU Lesser General
 Public License instead of this License.  But first, please read
-&lt;<a href="https://www.gnu.org/philosophy/why-not-lgpl.html">https://www.gnu.org/philosophy/why-not-lgpl.html</a>&gt;.
+&lt;<a href="https://www.gnu.org/licenses/why-not-lgpl.html">https://www.gnu.org/licenses/why-not-lgpl.html</a>&gt;.


### PR DESCRIPTION
update [the website's license page](https://rsync.samba.org/GPL.html) by copying the changes from the root COPYING file:

* openssl & xxhash exceptions
* updated link to Why-Not-LGPL