### PR TITLE
testsuite: bound the unshare probe

### DIFF
--- a/testsuite/protected-regular_test.py
+++ b/testsuite/protected-regular_test.py
@@ -49,11 +49,17 @@ if not _chown_5001(workdir / 'dst'):
     if not os.environ.get('RSYNC_UNSHARED'):
         unshare = shutil.which('unshare')
         if unshare is not None:
-            probe = subprocess.run(
-                [unshare, '--user', '--map-root-user',
-                 '--map-users', '5001:100000:1', 'true'],
-                capture_output=True,
-            )
+            try:
+                probe = subprocess.run(
+                    [unshare, '--user', '--map-root-user',
+                     '--map-users', '5001:100000:1', 'true'],
+                    stdin=subprocess.DEVNULL,
+                    stdout=subprocess.DEVNULL,
+                    stderr=subprocess.DEVNULL,
+                    timeout=5,
+                )
+            except subprocess.TimeoutExpired:
+                test_skipped("Can't chown (unshare probe timed out)")
             if probe.returncode == 0:
                 print("Re-running under unshare with UID mapping...")
                 env = os.environ.copy()


### PR DESCRIPTION
Fixes #1045

## Summary
- stop capturing output from the `protected-regular` unshare capability probe
- send its standard streams to `/dev/null` because only the return code is used
- add a five-second timeout so an abnormal probe cannot stall the complete testsuite