### PR TITLE
ci: stabilise Cygwin tests

### DIFF
--- a/.github/workflows/cygwin-build.yml
+++ b/.github/workflows/cygwin-build.yml
@@ -27,20 +27,33 @@ jobs:
         fetch-depth: 0
     - name: cygwin
       run: |
-        for ($attempt = 1; $attempt -le 3; $attempt++) {
-          choco install -y --no-progress cygwin cyg-get
-          if ($LASTEXITCODE -eq 0) {
-            break
-          }
-          if ($attempt -eq 3) {
-            exit $LASTEXITCODE
-          }
-          Start-Sleep -Seconds (15 * $attempt)
+        $setup = Join-Path $Env:RUNNER_TEMP 'setup-x86_64.exe'
+        $sums = Join-Path $Env:RUNNER_TEMP 'cygwin-sha512.sum'
+        $packages = 'make,autoconf,automake,gcc-core,attr,libattr-devel,python39,python39-pip,libzstd-devel,liblz4-devel,libssl-devel,libxxhash0,libxxhash-devel'
+
+        Invoke-WebRequest https://cygwin.com/setup-x86_64.exe -OutFile $setup
+        Invoke-WebRequest https://cygwin.com/sha512.sum -OutFile $sums
+
+        $sum = Select-String -LiteralPath $sums -Pattern '^[0-9a-fA-F]{128}\s+\*?setup-x86_64\.exe$' | Select-Object -First 1
+        if (-not $sum) {
+          throw 'setup-x86_64.exe is missing from Cygwin sha512.sum'
         }
-    - name: prep
-      run: |
-        cyg-get make autoconf automake gcc-core attr libattr-devel python39 python39-pip libzstd-devel liblz4-devel libssl-devel libxxhash0 libxxhash-devel
-        echo "C:/tools/cygwin/bin" >>$Env:GITHUB_PATH
+        $expected = ($sum.Line -split '\s+')[0]
+        $actual = (Get-FileHash -LiteralPath $setup -Algorithm SHA512).Hash
+        if ($actual -ine $expected) {
+          throw 'Cygwin setup SHA-512 mismatch'
+        }
+
+        & $setup --quiet-mode --wait --no-admin --no-desktop --no-startmenu --no-shortcuts `
+          --root C:\tools\cygwin `
+          --local-package-dir (Join-Path $Env:RUNNER_TEMP 'cygwin-packages') `
+          --site https://mirrors.kernel.org/sourceware/cygwin/ `
+          --packages $packages
+        if ($LASTEXITCODE -ne 0) {
+          exit $LASTEXITCODE
+        }
+
+        echo 'C:/tools/cygwin/bin' >>$Env:GITHUB_PATH
     - name: commonmark
       run: bash -c 'python3 -mpip install --user commonmark'
     - name: configure

--- a/.github/workflows/cygwin-build.yml
+++ b/.github/workflows/cygwin-build.yml
@@ -26,7 +26,17 @@ jobs:
       with:
         fetch-depth: 0
     - name: cygwin
-      run: choco install -y --no-progress cygwin cyg-get
+      run: |
+        for ($attempt = 1; $attempt -le 3; $attempt++) {
+          choco install -y --no-progress cygwin cyg-get
+          if ($LASTEXITCODE -eq 0) {
+            break
+          }
+          if ($attempt -eq 3) {
+            exit $LASTEXITCODE
+          }
+          Start-Sleep -Seconds (15 * $attempt)
+        }
     - name: prep
       run: |
         cyg-get make autoconf automake gcc-core attr libattr-devel python39 python39-pip libzstd-devel liblz4-devel libssl-devel libxxhash0 libxxhash-devel

--- a/.github/workflows/cygwin-build.yml
+++ b/.github/workflows/cygwin-build.yml
@@ -44,13 +44,28 @@ jobs:
           throw 'Cygwin setup SHA-512 mismatch'
         }
 
-        & $setup --quiet-mode --wait --no-admin --no-desktop --no-startmenu --no-shortcuts `
-          --root C:\tools\cygwin `
-          --local-package-dir (Join-Path $Env:RUNNER_TEMP 'cygwin-packages') `
-          --site https://mirrors.kernel.org/sourceware/cygwin/ `
-          --packages $packages
+        $arguments = @(
+          '--quiet-mode',
+          '--no-desktop',
+          '--no-startmenu',
+          '--no-shortcuts',
+          '--root', 'C:\tools\cygwin',
+          '--local-package-dir', (Join-Path $Env:RUNNER_TEMP 'cygwin-packages'),
+          '--site', 'https://mirrors.kernel.org/sourceware/cygwin/',
+          '--packages', $packages
+        )
+        $install = Start-Process -FilePath $setup -ArgumentList $arguments -Wait -PassThru -NoNewWindow
+        if ($install.ExitCode -ne 0) {
+          exit $install.ExitCode
+        }
+
+        $bash = 'C:\tools\cygwin\bin\bash.exe'
+        if (-not (Test-Path -LiteralPath $bash)) {
+          throw 'Cygwin setup did not install bash'
+        }
+        & $bash -lc 'command -v make aclocal gcc python3 >/dev/null'
         if ($LASTEXITCODE -ne 0) {
-          exit $LASTEXITCODE
+          throw 'Cygwin setup did not install all required build tools'
         }
 
         echo 'C:/tools/cygwin/bin' >>$Env:GITHUB_PATH

--- a/testsuite/sender-remove-source-secure_test.py
+++ b/testsuite/sender-remove-source-secure_test.py
@@ -48,6 +48,10 @@ try:
                 os.utime(inside_file, (st.st_atime, st.st_mtime))
             except FileNotFoundError:
                 pass
+            except PermissionError:
+                # Cygwin can report EACCES while the flipper swaps this path.
+                if not _CYGWIN:
+                    raise
         subprocess.run(
             rsync_argv('-a', '--remove-source-files', f'{url}src/real/file', str(dest) + '/'),
             stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, text=True)


### PR DESCRIPTION
## Summary
- retry transient Chocolatey failures while installing Cygwin
- tolerate Cygwin's transient `EACCES` while the sender race fixture swaps its test path
- preserve strict `PermissionError` handling on other platforms