### PR TITLE
ci: run PR checks without labels

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -1,5 +1,9 @@
 name: Lint GitHub Actions workflows
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
 # Static-check the workflow YAML with rhysd/actionlint.  Catches missing
 # secrets, bad expressions, expression-type errors, unsupported runner
 # images, and (via embedded shellcheck) common pitfalls in `run:` scripts.
@@ -14,7 +18,7 @@ on:
       - '.github/actionlint.yaml'
       - '.github/actionlint.yml'
   pull_request:
-    types: [opened, synchronize, reopened, labeled]
+    types: [opened, synchronize, reopened]
     paths:
       - '.github/workflows/*.yml'
       - '.github/actionlint.yaml'
@@ -25,9 +29,6 @@ permissions:
 
 jobs:
   actionlint:
-    # temporary gate: PR CI runs only for PRs labeled 'run-ci', to save CI
-    # minutes; labels need triage access, so fork PRs can't self-enable.
-    if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'run-ci')
     runs-on: ubuntu-latest
     name: actionlint
     steps:

--- a/.github/workflows/almalinux-8-build.yml
+++ b/.github/workflows/almalinux-8-build.yml
@@ -1,5 +1,9 @@
 name: Test rsync on AlmaLinux 8
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
 # Older-LTS coverage on the Fedora/RHEL family to help with backporting
 # security fixes. AlmaLinux 8 is the RHEL 8 rebuild and is the oldest
 # active LTS in this family (RHEL 8 full support runs to 2029).
@@ -13,7 +17,7 @@ on:
       - '.github/workflows/*.yml'
       - '!.github/workflows/almalinux-8-build.yml'
   pull_request:
-    types: [opened, synchronize, reopened, labeled]
+    types: [opened, synchronize, reopened]
     paths-ignore:
       - '.github/workflows/*.yml'
       - '!.github/workflows/almalinux-8-build.yml'
@@ -22,9 +26,6 @@ on:
 
 jobs:
   test:
-    # temporary gate: PR CI runs only for PRs labeled 'run-ci', to save CI
-    # minutes; labels need triage access, so fork PRs can't self-enable.
-    if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'run-ci')
     runs-on: ubuntu-latest
     container:
       image: almalinux:8

--- a/.github/workflows/android-static-build.yml
+++ b/.github/workflows/android-static-build.yml
@@ -1,5 +1,9 @@
 name: Build static rsync for Android
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
 # Cross-compiles statically-linked rsync binaries with the Android NDK,
 # suitable for dropping onto a phone (adb push / Termux) with no shared
 # libraries. arm64-v8a covers all modern phones; armeabi-v7a covers older
@@ -16,7 +20,7 @@ on:
       - '.github/workflows/*.yml'
       - '!.github/workflows/android-static-build.yml'
   pull_request:
-    types: [opened, synchronize, reopened, labeled]
+    types: [opened, synchronize, reopened]
     paths-ignore:
       - '.github/workflows/*.yml'
       - '!.github/workflows/android-static-build.yml'
@@ -31,9 +35,6 @@ env:
 
 jobs:
   build:
-    # temporary gate: PR CI runs only for PRs labeled 'run-ci', to save CI
-    # minutes; labels need triage access, so fork PRs can't self-enable.
-    if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'run-ci')
     runs-on: ubuntu-latest
     name: ${{ matrix.abi }}
     strategy:

--- a/.github/workflows/asan-build.yml
+++ b/.github/workflows/asan-build.yml
@@ -1,5 +1,9 @@
 name: rsync ASan+UBSan (clang)
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
 on:
   push:
     branches: [ master ]
@@ -7,7 +11,7 @@ on:
       - '.github/workflows/*.yml'
       - '!.github/workflows/asan-build.yml'
   pull_request:
-    types: [opened, synchronize, reopened, labeled]
+    types: [opened, synchronize, reopened]
     paths-ignore:
       - '.github/workflows/*.yml'
       - '!.github/workflows/asan-build.yml'
@@ -21,9 +25,6 @@ on:
 
 jobs:
   asan:
-    # temporary gate: PR CI runs only for PRs labeled 'run-ci', to save CI
-    # minutes; labels need triage access, so fork PRs can't self-enable.
-    if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'run-ci')
     runs-on: ubuntu-latest
     name: rsync ASan+UBSan (clang)
     env:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,5 +1,9 @@
 name: Coverage (Ubuntu)
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
 on:
   push:
     branches: [ master ]
@@ -7,7 +11,7 @@ on:
       - '.github/workflows/*.yml'
       - '!.github/workflows/coverage.yml'
   pull_request:
-    types: [opened, synchronize, reopened, labeled]
+    types: [opened, synchronize, reopened]
     paths-ignore:
       - '.github/workflows/*.yml'
       - '!.github/workflows/coverage.yml'
@@ -17,9 +21,6 @@ on:
 
 jobs:
   coverage:
-    # temporary gate: PR CI runs only for PRs labeled 'run-ci', to save CI
-    # minutes; labels need triage access, so fork PRs can't self-enable.
-    if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'run-ci')
     runs-on: ubuntu-latest
     name: gcov coverage
     steps:

--- a/.github/workflows/cygwin-build.yml
+++ b/.github/workflows/cygwin-build.yml
@@ -1,5 +1,9 @@
 name: Test rsync on Cygwin
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
 on:
   push:
     branches: [ master ]
@@ -7,7 +11,7 @@ on:
       - '.github/workflows/*.yml'
       - '!.github/workflows/cygwin-build.yml'
   pull_request:
-    types: [opened, synchronize, reopened, labeled]
+    types: [opened, synchronize, reopened]
     paths-ignore:
       - '.github/workflows/*.yml'
       - '!.github/workflows/cygwin-build.yml'
@@ -16,9 +20,6 @@ on:
 
 jobs:
   test:
-    # temporary gate: PR CI runs only for PRs labeled 'run-ci', to save CI
-    # minutes; labels need triage access, so fork PRs can't self-enable.
-    if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'run-ci')
     runs-on: windows-2022
     name: Test rsync on Cygwin
     steps:

--- a/.github/workflows/fleettest.yml
+++ b/.github/workflows/fleettest.yml
@@ -1,5 +1,9 @@
 name: Test fleettest harness
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
 # Bitrot check for testsuite/fleettest.py (the developer fleet CI harness).
 # fleettest is meant to be run by developers on a modern Ubuntu box, so this
 # job runs only on ubuntu-latest: it stands up a one-host "fleet" of two
@@ -16,7 +20,7 @@ on:
       - 'testsuite/skiplist/**'
       - 'testsuite/skiplist-spec_test.py'
   pull_request:
-    types: [opened, synchronize, reopened, labeled]
+    types: [opened, synchronize, reopened]
     paths:
       - 'testsuite/fleettest.py'
       - '.github/workflows/fleettest.yml'
@@ -29,9 +33,6 @@ on:
 
 jobs:
   fleettest:
-    # temporary gate: PR CI runs only for PRs labeled 'run-ci', to save CI
-    # minutes; labels need triage access, so fork PRs can't self-enable.
-    if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'run-ci')
     runs-on: ubuntu-latest
     name: fleettest against localhost
     steps:

--- a/.github/workflows/freebsd-build.yml
+++ b/.github/workflows/freebsd-build.yml
@@ -1,5 +1,9 @@
 name: Test rsync on FreeBSD
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
 on:
   push:
     branches: [ master ]
@@ -7,7 +11,7 @@ on:
       - '.github/workflows/*.yml'
       - '!.github/workflows/freebsd-build.yml'
   pull_request:
-    types: [opened, synchronize, reopened, labeled]
+    types: [opened, synchronize, reopened]
     paths-ignore:
       - '.github/workflows/*.yml'
       - '!.github/workflows/freebsd-build.yml'
@@ -16,9 +20,6 @@ on:
 
 jobs:
   test:
-    # temporary gate: PR CI runs only for PRs labeled 'run-ci', to save CI
-    # minutes; labels need triage access, so fork PRs can't self-enable.
-    if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'run-ci')
     runs-on: ubuntu-latest
     name: Test rsync on FreeBSD
     steps:

--- a/.github/workflows/macos-build.yml
+++ b/.github/workflows/macos-build.yml
@@ -1,5 +1,9 @@
 name: Test rsync on macOS
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
 on:
   push:
     branches: [ master ]
@@ -7,7 +11,7 @@ on:
       - '.github/workflows/*.yml'
       - '!.github/workflows/macos-build.yml'
   pull_request:
-    types: [opened, synchronize, reopened, labeled]
+    types: [opened, synchronize, reopened]
     paths-ignore:
       - '.github/workflows/*.yml'
       - '!.github/workflows/macos-build.yml'
@@ -16,9 +20,6 @@ on:
 
 jobs:
   test:
-    # temporary gate: PR CI runs only for PRs labeled 'run-ci', to save CI
-    # minutes; labels need triage access, so fork PRs can't self-enable.
-    if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'run-ci')
     runs-on: macos-latest
     name: Test rsync on macOS
     steps:

--- a/.github/workflows/netbsd-build.yml
+++ b/.github/workflows/netbsd-build.yml
@@ -1,5 +1,9 @@
 name: Test rsync on NetBSD
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
 on:
   push:
     branches: [ master ]
@@ -7,7 +11,7 @@ on:
       - '.github/workflows/*.yml'
       - '!.github/workflows/netbsd-build.yml'
   pull_request:
-    types: [opened, synchronize, reopened, labeled]
+    types: [opened, synchronize, reopened]
     paths-ignore:
       - '.github/workflows/*.yml'
       - '!.github/workflows/netbsd-build.yml'
@@ -16,9 +20,6 @@ on:
 
 jobs:
   test:
-    # temporary gate: PR CI runs only for PRs labeled 'run-ci', to save CI
-    # minutes; labels need triage access, so fork PRs can't self-enable.
-    if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'run-ci')
     runs-on: ubuntu-latest
     name: Test rsync on NetBSD
     steps:

--- a/.github/workflows/openbsd-build.yml
+++ b/.github/workflows/openbsd-build.yml
@@ -1,5 +1,9 @@
 name: Test rsync on OpenBSD
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
 on:
   push:
     branches: [ master ]
@@ -7,7 +11,7 @@ on:
       - '.github/workflows/*.yml'
       - '!.github/workflows/openbsd-build.yml'
   pull_request:
-    types: [opened, synchronize, reopened, labeled]
+    types: [opened, synchronize, reopened]
     paths-ignore:
       - '.github/workflows/*.yml'
       - '!.github/workflows/openbsd-build.yml'
@@ -16,9 +20,6 @@ on:
 
 jobs:
   test:
-    # temporary gate: PR CI runs only for PRs labeled 'run-ci', to save CI
-    # minutes; labels need triage access, so fork PRs can't self-enable.
-    if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'run-ci')
     runs-on: ubuntu-latest
     name: Test rsync on OpenBSD
     steps:

--- a/.github/workflows/scan-build.yml
+++ b/.github/workflows/scan-build.yml
@@ -1,5 +1,9 @@
 name: rsync scan-build (clang analyzer)
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
 on:
   push:
     branches: [ master ]
@@ -7,7 +11,7 @@ on:
       - '.github/workflows/*.yml'
       - '!.github/workflows/scan-build.yml'
   pull_request:
-    types: [opened, synchronize, reopened, labeled]
+    types: [opened, synchronize, reopened]
     paths-ignore:
       - '.github/workflows/*.yml'
       - '!.github/workflows/scan-build.yml'
@@ -20,9 +24,6 @@ jobs:
   # when a new finding appears.  Pin both the analyzer (clang-18/clang-tools-18)
   # and the runner (ubuntu-24.04, whose apt repos carry those packages).
   gate-clang18:
-    # temporary gate: PR CI runs only for PRs labeled 'run-ci', to save CI
-    # minutes; labels need triage access, so fork PRs can't self-enable.
-    if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'run-ci')
     runs-on: ubuntu-24.04
     name: scan-build gate (clang-18, pinned)
     steps:
@@ -64,9 +65,6 @@ jobs:
   # gate bump -- without blocking merges.  continue-on-error keeps a noisy or
   # broken run from affecting the workflow's required status.
   informational-latest:
-    # temporary gate: PR CI runs only for PRs labeled 'run-ci', to save CI
-    # minutes; labels need triage access, so fork PRs can't self-enable.
-    if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'run-ci')
     runs-on: ubuntu-latest
     name: scan-build (latest clang, informational)
     continue-on-error: true

--- a/.github/workflows/solaris-build.yml
+++ b/.github/workflows/solaris-build.yml
@@ -1,5 +1,9 @@
 name: Test rsync on Solaris
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
 on:
   push:
     branches: [ master ]
@@ -7,7 +11,7 @@ on:
       - '.github/workflows/*.yml'
       - '!.github/workflows/solaris-build.yml'
   pull_request:
-    types: [opened, synchronize, reopened, labeled]
+    types: [opened, synchronize, reopened]
     paths-ignore:
       - '.github/workflows/*.yml'
       - '!.github/workflows/solaris-build.yml'
@@ -16,9 +20,6 @@ on:
 
 jobs:
   test:
-    # temporary gate: PR CI runs only for PRs labeled 'run-ci', to save CI
-    # minutes; labels need triage access, so fork PRs can't self-enable.
-    if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'run-ci')
     runs-on: ubuntu-latest
     name: Test rsync on Solaris
     steps:

--- a/.github/workflows/ubuntu-22.04-build.yml
+++ b/.github/workflows/ubuntu-22.04-build.yml
@@ -1,5 +1,9 @@
 name: Test rsync on Ubuntu 22.04
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
 # Older-LTS coverage to help with backporting security fixes. ubuntu-22.04
 # is currently the oldest GitHub Actions runner image (20.04 was retired
 # in April 2025).
@@ -11,7 +15,7 @@ on:
       - '.github/workflows/*.yml'
       - '!.github/workflows/ubuntu-22.04-build.yml'
   pull_request:
-    types: [opened, synchronize, reopened, labeled]
+    types: [opened, synchronize, reopened]
     paths-ignore:
       - '.github/workflows/*.yml'
       - '!.github/workflows/ubuntu-22.04-build.yml'
@@ -20,9 +24,6 @@ on:
 
 jobs:
   test:
-    # temporary gate: PR CI runs only for PRs labeled 'run-ci', to save CI
-    # minutes; labels need triage access, so fork PRs can't self-enable.
-    if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'run-ci')
     runs-on: ubuntu-22.04
     name: Test rsync on Ubuntu 22.04
     steps:

--- a/.github/workflows/ubuntu-build.yml
+++ b/.github/workflows/ubuntu-build.yml
@@ -1,5 +1,9 @@
 name: Test rsync on Ubuntu
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
 on:
   push:
     branches: [ master ]
@@ -7,7 +11,7 @@ on:
       - '.github/workflows/*.yml'
       - '!.github/workflows/ubuntu-build.yml'
   pull_request:
-    types: [opened, synchronize, reopened, labeled]
+    types: [opened, synchronize, reopened]
     paths-ignore:
       - '.github/workflows/*.yml'
       - '!.github/workflows/ubuntu-build.yml'
@@ -16,9 +20,6 @@ on:
 
 jobs:
   test:
-    # temporary gate: PR CI runs only for PRs labeled 'run-ci', to save CI
-    # minutes; labels need triage access, so fork PRs can't self-enable.
-    if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'run-ci')
     runs-on: ubuntu-latest
     name: Test rsync on Ubuntu
     steps:

--- a/.github/workflows/ubuntu-version-mix.yml
+++ b/.github/workflows/ubuntu-version-mix.yml
@@ -1,5 +1,9 @@
 name: Test rsync version mixing on Ubuntu
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
 # Runs the CURRENT test suite with two different rsync binaries: the freshly
 # built ./rsync as the client/driver, and a committed OLD static binary
 # (old_versions/rsync_<ver>) as the daemon / remote-shell peer. This exercises
@@ -28,7 +32,7 @@ on:
       - '.github/workflows/*.yml'
       - '!.github/workflows/ubuntu-version-mix.yml'
   pull_request:
-    types: [opened, synchronize, reopened, labeled]
+    types: [opened, synchronize, reopened]
     paths-ignore:
       - '.github/workflows/*.yml'
       - '!.github/workflows/ubuntu-version-mix.yml'
@@ -37,9 +41,6 @@ on:
 
 jobs:
   version-mix:
-    # temporary gate: PR CI runs only for PRs labeled 'run-ci', to save CI
-    # minutes; labels need triage access, so fork PRs can't self-enable.
-    if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'run-ci')
     runs-on: ubuntu-latest
     name: rsync version-mix
     steps:

--- a/.github/workflows/valgrind.yml
+++ b/.github/workflows/valgrind.yml
@@ -1,5 +1,9 @@
 name: Valgrind memcheck
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
 on:
   push:
     branches: [ master ]
@@ -7,7 +11,7 @@ on:
       - '.github/workflows/*.yml'
       - '!.github/workflows/valgrind.yml'
   pull_request:
-    types: [opened, synchronize, reopened, labeled]
+    types: [opened, synchronize, reopened]
     paths-ignore:
       - '.github/workflows/*.yml'
       - '!.github/workflows/valgrind.yml'
@@ -17,9 +21,6 @@ on:
 
 jobs:
   memcheck:
-    # temporary gate: PR CI runs only for PRs labeled 'run-ci', to save CI
-    # minutes; labels need triage access, so fork PRs can't self-enable.
-    if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'run-ci')
     runs-on: ubuntu-latest
     timeout-minutes: 120
     strategy:


### PR DESCRIPTION
## Summary
- remove the temporary `run-ci` label requirement from all PR workflows
- cancel superseded runs of the same workflow when a PR is updated
- stop triggering CI when labels are added or removed